### PR TITLE
move the logic of checking stream key duplication into the function of format_timeseries

### DIFF
--- a/src/write_gcm.c
+++ b/src/write_gcm.c
@@ -489,15 +489,12 @@ static int format_timeseries(char *buffer, /* {{{ */
   if (FORMAT_VL(stream_key, sizeof(stream_key), vl) != 0) {
       ERROR("value_to_timeseries: FORMAT_VL failed.");
       return -1;
-  } else if (cb->stream_key_tree &&
-             c_avl_get(cb->stream_key_tree, stream_key, NULL) == 0) {
-    return -1;
-  }
-
-  if (cb->stream_key_tree == NULL) {
+  } else if (cb->stream_key_tree == NULL) {
     cb->stream_key_tree =
         c_avl_create((int (*)(const void *, const void *))strcmp);
-  };
+  } else if (c_avl_get(cb->stream_key_tree, stream_key, NULL) == 0) {
+    return -1;
+  }
   c_avl_insert(cb->stream_key_tree, strdup(stream_key), NULL);
 
   return (format_timeseries_nocheck(buffer, ret_buffer_fill, ret_buffer_free,


### PR DESCRIPTION
I found a bug where if we found a existing key and then flush the buffer, the newly found duplicate stream key is not added into the stream key cache tree, but it's in the send buffer, which will results in duplication error next time we send the request.

key1: ts 1 -> cache{key1}, buffer {key1}
key2: ts 1 -> cache{key1,key2} buffer {key1, key2}
key1: ts 2 
  -> found key1 in cache and flush, -> cache{}, buffer{}
 -> add key1 into buffer using format_timeseries function -> buffer{key1}

key2: ts2 cache{key2}, buffer{key1, key2}
key1: ts3 cache{key1, key2} buffer{key1, key2, key1} //duplicate keys
