### PR TITLE
swtich to the version modified by octo

### DIFF
--- a/src/write_gcm.c
+++ b/src/write_gcm.c
@@ -73,9 +73,7 @@
 
 #define MONITORING_URL \
   "https://www.googleapis.com/cloudmonitoring/v2beta2"
-/* TODO(zhihuawen) change the scope to monitoring when it's working */
-#define MONITORING_SCOPE "https://www.googleapis.com/auth/monitoring.readonly"
-//#define MONITORING_SCOPE "https://www.googleapis.com/auth/monitoring"
+#define MONITORING_SCOPE "https://www.googleapis.com/auth/monitoring"
 #define GCE_METADATA_FLAVOR "Metadata-Flavor: Google"
 #define METADATA_PREFIX "http://169.254.169.254/"
 #define METADATA_HEADER "X-Google-Metadata-Request: True"


### PR DESCRIPTION
octo has been optimized a version of write_gcm.c in https://github.com/GoogleCloudPlatform/collectd-gcm-sd/tree/octo/gcm, which is cleaner and more readable than mine original version. Since that one will likely be the official one when the clam api is GA, we should better use the same version here for maintainability.
