### PR TITLE
fix multiple-definition bug in write_http.c

### DIFF
--- a/src/write_http.c
+++ b/src/write_http.c
@@ -50,7 +50,6 @@ struct wh_callback_s
         int   verify_peer;
         int   verify_host;
         char *cacert;
-        int   store_rates;
         _Bool store_rates;
 	_Bool abort_on_slow;
 	int   low_limit_bytes;


### PR DESCRIPTION
@katzj 

Oops, stupid copy/paste error.
