### PR TITLE
Fix mongodb memory leak (b/19450849)

### DIFF
--- a/src/mongodb.c
+++ b/src/mongodb.c
@@ -480,7 +480,6 @@ static int mc_db_stats_read_cb (user_data_t *ud) /* {{{ */
         return (-1);
     }
 
-    bson_init (&result);
     bson_init (&b);
     bson_append_int (&b, "dbStats", 1);
     bson_append_int (&b, "scale", 1);


### PR DESCRIPTION
'mongo_run_command' expects an uninitialized 'result' object. Initializing
it here causes a memory leak.

Tested:
  GCE Debian with a MongoDB instance with 100 databases. After this change,
  the memory leak rate is much slower. (There is still another leak, yet
  to be found, somewhere in the agent, but the rate of memory consumption
  is MUCH slower after this change).
