### PR TITLE
Ensure that mysql_library_init is called from every thread.

### DIFF
--- a/src/mysql.c
+++ b/src/mysql.c
@@ -238,6 +238,7 @@ static int mysql_config (oconfig_item_t *ci) /* {{{ */
 
 static MYSQL *getconnection (mysql_database_t *db)
 {
+	mysql_thread_init();
 	if (db->is_connected)
 	{
 		int status;
@@ -776,5 +777,6 @@ static int mysql_read (user_data_t *ud)
 
 void module_register (void)
 {
+	mysql_library_init(0, NULL, NULL);
 	plugin_register_complex_config ("mysql", mysql_config);
 } /* void module_register */


### PR DESCRIPTION
This is done by making the call inside getconnection().

(It is ok--and cheap--to make the init call every time).
