### PR TITLE
memcached_connections should probably be submitted as a gauge.

### DIFF
--- a/src/memcached.c
+++ b/src/memcached.c
@@ -439,7 +439,7 @@ static int memcached_read (user_data_t *user_data)
     }
     else if (FIELD_IS ("listen_disabled_num"))
     {
-      submit_derive ("memcached_connections", "listen_disabled", atof (fields[2]), st);
+      submit_gauge ("memcached_connections", "listen_disabled", atof (fields[2]), st);
     }
 
     /*


### PR DESCRIPTION
According to types.db, memcached_connections is a gauge. Apparently this is an obscure statistic, so it's possible this has gone unnoticed.