### PR TITLE
memcached plugin: Use a DERIVE type for the "listen disabled" metric.

### DIFF
--- a/src/memcached.c
+++ b/src/memcached.c
@@ -439,7 +439,7 @@ static int memcached_read (user_data_t *user_data)
     }
     else if (FIELD_IS ("listen_disabled_num"))
     {
-      submit_derive ("memcached_connections", "listen_disabled", atof (fields[2]), st);
+      submit_derive ("connections", "listen_disabled", atof (fields[2]), st);
     }
 
     /*


### PR DESCRIPTION
Fixes: #1356

(Cherry-pick of upstream commit 01e77b97fa9fe4979815fe0c8a533c9dc97aa1d1)
