### PR TITLE
Dedupe disks

### DIFF
--- a/src/df.c
+++ b/src/df.c
@@ -204,6 +204,7 @@ static int df_read (void)
 	{
 		unsigned long long blocksize;
 		char disk_name[256];
+        cu_mount_t *mnt_dup_ptr;
 		uint64_t blk_free;
 		uint64_t blk_reserved;
 		uint64_t blk_used;
@@ -217,6 +218,20 @@ static int df_read (void)
 			continue;
 		if (ignorelist_match (il_fstype, mnt_ptr->type))
 			continue;
+
+		/* ignore duplicates */
+		for (mnt_dup_ptr = mnt_ptr; mnt_dup_ptr != NULL; mnt_dup_ptr = mnt_dup_ptr->next)
+		{
+			if (by_device) {
+				if (strcmp (mnt_ptr->spec_device, mnt_dup_ptr->spec_device) == 0)
+					continue;
+			}
+			else
+			{
+				if (strcmp (mnt_ptr->dir, mnt_dup_ptr->dir) == 0)
+					continue;
+			}
+		}
 
 		if (STATANYFS (mnt_ptr->dir, &statbuf) < 0)
 		{

--- a/src/df.c
+++ b/src/df.c
@@ -204,7 +204,7 @@ static int df_read (void)
 	{
 		unsigned long long blocksize;
 		char disk_name[256];
-        cu_mount_t *mnt_dup_ptr;
+		cu_mount_t *dup_ptr;
 		uint64_t blk_free;
 		uint64_t blk_reserved;
 		uint64_t blk_used;
@@ -219,19 +219,26 @@ static int df_read (void)
 		if (ignorelist_match (il_fstype, mnt_ptr->type))
 			continue;
 
-		/* ignore duplicates */
-		for (mnt_dup_ptr = mnt_ptr; mnt_dup_ptr != NULL; mnt_dup_ptr = mnt_dup_ptr->next)
+		/* search for duplicates *in front of* the current mnt_ptr. */
+		for (dup_ptr = mnt_list; dup_ptr != NULL; dup_ptr = dup_ptr->next)
 		{
-			if (by_device) {
-				if (strcmp (mnt_ptr->spec_device, mnt_dup_ptr->spec_device) == 0)
-					continue;
-			}
-			else
+			/* No duplicate found: mnt_ptr is the first of its kind. */
+			if (dup_ptr == mnt_ptr)
 			{
-				if (strcmp (mnt_ptr->dir, mnt_dup_ptr->dir) == 0)
-					continue;
+				dup_ptr = NULL;
+				break;
 			}
+
+			/* Duplicate found: leave non-NULL dup_ptr. */
+			if (by_device && (strcmp (mnt_ptr->spec_device, dup_ptr->spec_device) == 0))
+				break;
+			else if (!by_device && (strcmp (mnt_ptr->dir, dup_ptr->dir) == 0))
+				break;
 		}
+
+		/* ignore duplicates */
+		if (dup_ptr != NULL)
+			continue;
 
 		if (STATANYFS (mnt_ptr->dir, &statbuf) < 0)
 		{


### PR DESCRIPTION
Cherry picking some changes from upstream so we don't send metrics for the same device more than once.
