### PR TITLE
[part 2/4] Unified signature for ps_get_cmdline

### DIFF
--- a/src/processes.c
+++ b/src/processes.c
@@ -1189,8 +1189,8 @@ static int read_fork_rate ()
 #endif /*KERNEL_LINUX */
 
 #if KERNEL_SOLARIS
-static const char *ps_get_cmdline (long pid, /* {{{ */
-		char *buffer, size_t buffer_size)
+static char *ps_get_cmdline (pid_t pid, char *name, /* {{{ */
+    char *buffer, size_t buffer_size)
 {
 	char path[PATH_MAX];
 	psinfo_t info;
@@ -2282,7 +2282,7 @@ static int ps_read (void)
 
 
 		ps_list_add (ps.name,
-				ps_get_cmdline (pid, cmdline, sizeof (cmdline)),
+				ps_get_cmdline (pid, ps.name, cmdline, sizeof (cmdline)),
 				&pse);
 	} /* while(readdir) */
 	closedir (proc);


### PR DESCRIPTION
```ps_get_cmdline``` is defined differently (including having a different signature) depending on whether ```KERNEL_LINUX``` or ```KERNEL_SOLARIS``` is defined. This means callers have to have two different calls as well, controlled by those variables.

This change unifies their signatures so callers don't have to care. (See line 1050 for the KERNEL_LINUX version).