### PR TITLE
[part 3/4] processes plugin sends additional data in metadata

### DIFF
--- a/src/processes.c
+++ b/src/processes.c
@@ -217,6 +217,26 @@ typedef struct procstat
 
 static procstat_t *list_head_g = NULL;
 
+// MODE_GROUP needs to be 0 so that static initialization works as expected.
+typedef enum { MODE_GROUP = 0, MODE_DETAIL } group_or_detail_mode_t;
+
+typedef struct
+{
+    group_or_detail_mode_t ps_count;
+    group_or_detail_mode_t ps_vm;
+    group_or_detail_mode_t ps_rss;
+    group_or_detail_mode_t ps_data;
+    group_or_detail_mode_t ps_code;
+    group_or_detail_mode_t ps_stacksize;
+    group_or_detail_mode_t ps_cputime;
+    group_or_detail_mode_t ps_pagefaults;
+    group_or_detail_mode_t ps_disk_octets;
+    group_or_detail_mode_t ps_disk_ops;
+} mode_configuration_t;
+
+static mode_configuration_t mode_configuration_g;
+_Bool some_mode_configured_to_detail_g = 0;
+
 #if HAVE_THREAD_INFO
 static mach_port_t port_host_self;
 static mach_port_t port_task_self;
@@ -522,6 +542,32 @@ static int ps_config (oconfig_item_t *ci)
 {
 	int i;
 
+    const char *stat_names[] = {
+        "ps_count",
+        "ps_vm",
+        "ps_rss",
+        "ps_data",
+        "ps_code",
+        "ps_stacksize",
+        "ps_cputime",
+        "ps_pagefaults",
+        "ps_disk_octets",
+        "ps_disk_ops"
+    };
+
+    group_or_detail_mode_t *stat_flags[] = {
+        &mode_configuration_g.ps_count,
+        &mode_configuration_g.ps_vm,
+        &mode_configuration_g.ps_rss,
+        &mode_configuration_g.ps_data,
+        &mode_configuration_g.ps_code,
+        &mode_configuration_g.ps_stacksize,
+        &mode_configuration_g.ps_cputime,
+        &mode_configuration_g.ps_pagefaults,
+        &mode_configuration_g.ps_disk_octets,
+        &mode_configuration_g.ps_disk_ops
+    };
+
 	for (i = 0; i < ci->children_num; ++i) {
 		oconfig_item_t *c = ci->children + i;
 
@@ -566,6 +612,34 @@ static int ps_config (oconfig_item_t *ci)
 
 			ps_list_register (c->values[0].value.string,
 					c->values[1].value.string);
+		}
+		else if (strcasecmp (c->key, "Detail") == 0)
+		{
+		    int sn;
+		    if ((c->values_num != 1)
+		            || (OCONFIG_TYPE_STRING != c->values[0].type))
+		    {
+		        ERROR ("processes plugin: `Detail' needs exactly "
+		                "one string argument (got %i).",
+		                c->values_num);
+		        continue;
+		    }
+		    assert (STATIC_ARRAY_SIZE (stat_names) ==
+		            STATIC_ARRAY_SIZE (stat_flags));
+		    for (sn = 0; sn < STATIC_ARRAY_SIZE(stat_names); ++sn) {
+		        if (strcasecmp(c->values[0].value.string, stat_names[sn]) == 0)
+		        {
+		            *stat_flags[sn] = MODE_DETAIL;
+		            some_mode_configured_to_detail_g = 1;
+		            break;
+		        }
+		    }
+		    if (sn == STATIC_ARRAY_SIZE(stat_names))
+		    {
+		        ERROR ("processes plugin: Unrecognized `Detail' argument %s.",
+		               c->values[0].value.string);
+		        continue;
+		    }
 		}
 		else
 		{
@@ -643,93 +717,223 @@ static void ps_submit_state (const char *state, double value)
 	plugin_dispatch_values (&vl);
 }
 
-/* submit info about specific process (e.g.: memory taken, cpu usage, etc..) */
+static char *ps_get_cmdline (pid_t pid, char *name,
+    char *buf, size_t buf_len);
+static char *ps_get_command(pid_t pid);
+static char *ps_get_owner(pid_t pid);
+
+// Increase this value if any of the callers use a larger 'values_len'.
+// (You'll immediately notice if the assertion fails).
+#define MAX_VALUE_LIST_SIZE 2
+
+static void dispatch_value_helper (value_list_t *vl,
+        const char *type_name, int values_len,
+        group_or_detail_mode_t mode, group_or_detail_mode_t mode_filter)
+{
+    assert (values_len <= MAX_VALUE_LIST_SIZE);
+    if (mode != mode_filter)
+    {
+        return;
+    }
+    sstrncpy(vl->type, type_name, sizeof (vl->type));
+    vl->values_len = values_len;
+    plugin_dispatch_values(vl);
+}
+
+static void ps_submit_proc_stats (
+        group_or_detail_mode_t mode,
+        const char *instance_name,
+        const char *pid,
+        const char *owner,
+        const char *command,
+        const char *command_line,
+        unsigned long num_proc,
+        unsigned long num_lwp,
+        unsigned long vmem_size,
+        unsigned long vmem_rss,
+        unsigned long vmem_data,
+        unsigned long vmem_code,
+        unsigned long stack_size,
+        derive_t vmem_minflt_counter,
+        derive_t vmem_majflt_counter,
+        derive_t cpu_user_counter,
+        derive_t cpu_system_counter,
+        derive_t io_rchar,
+        derive_t io_wchar,
+        derive_t io_syscr,
+        derive_t io_syscw)
+{
+    const mode_configuration_t *config = &mode_configuration_g;
+    value_t values[MAX_VALUE_LIST_SIZE];
+    value_list_t vl = VALUE_LIST_INIT;
+    vl.values = values;
+
+    sstrncpy (vl.host, hostname_g, sizeof (vl.host));
+    sstrncpy (vl.plugin, "processes", sizeof (vl.plugin));
+    sstrncpy (vl.plugin_instance, instance_name, sizeof (vl.plugin_instance));
+
+    if (pid != NULL || owner != NULL || command != NULL || command_line != NULL)
+    {
+        vl.meta = meta_data_create();
+        if (pid != NULL) {
+            meta_data_add_string(vl.meta, "processes:pid", pid);
+        }
+        if (owner != NULL) {
+            meta_data_add_string(vl.meta, "processes:owner", owner);
+        }
+        if (command != NULL) {
+            meta_data_add_string(vl.meta, "processes:command", command);
+        }
+        if (command_line != NULL) {
+            meta_data_add_string(vl.meta, "processes:command_line",
+                    command_line);
+        }
+    }
+
+    vl.values[0].gauge = num_proc;
+    vl.values[1].gauge = num_lwp;
+    dispatch_value_helper(&vl, "ps_count", 2, mode, config->ps_count);
+
+    vl.values[0].gauge = vmem_size;
+    dispatch_value_helper(&vl, "ps_vm", 1, mode, config->ps_vm);
+
+    vl.values[0].gauge = vmem_rss;
+    dispatch_value_helper(&vl, "ps_rss", 1, mode, config->ps_rss);
+
+    vl.values[0].gauge = vmem_data;
+    dispatch_value_helper(&vl, "ps_data", 1, mode, config->ps_data);
+
+    vl.values[0].gauge = vmem_code;
+    dispatch_value_helper(&vl, "ps_code", 1, mode, config->ps_code);
+
+    vl.values[0].gauge = stack_size;
+    dispatch_value_helper(&vl, "ps_stacksize", 1, mode, config->ps_stacksize);
+
+    vl.values[0].derive = vmem_minflt_counter;
+    vl.values[1].derive = vmem_majflt_counter;
+    dispatch_value_helper(&vl, "ps_pagefaults", 2, mode, config->ps_pagefaults);
+
+    vl.values[0].derive = cpu_user_counter;
+    vl.values[1].derive = cpu_system_counter;
+    dispatch_value_helper(&vl, "ps_cputime", 2, mode, config->ps_cputime);
+
+    if ( (io_rchar != -1) && (io_wchar != -1) )
+    {
+        vl.values[0].derive = io_rchar;
+        vl.values[1].derive = io_wchar;
+        dispatch_value_helper(&vl, "ps_disk_octets", 2, mode,
+                config->ps_disk_octets);
+    }
+
+    if ( (io_syscr != -1) && (io_syscw != -1) )
+    {
+        vl.values[0].derive = io_syscr;
+        vl.values[1].derive = io_syscw;
+        dispatch_value_helper(&vl, "ps_disk_ops", 2, mode, config->ps_disk_ops);
+        plugin_dispatch_values (&vl);
+    }
+
+    if (vl.meta != NULL) {
+        meta_data_destroy(vl.meta);
+        vl.meta = NULL;
+    }
+
+    DEBUG ("name = %s; num_proc = %lu; num_lwp = %lu; "
+            "vmem_size = %lu; vmem_rss = %lu; vmem_data = %lu; "
+            "vmem_code = %lu; "
+            "vmem_minflt_counter = %"PRIi64"; vmem_majflt_counter = %"PRIi64"; "
+            "cpu_user_counter = %"PRIi64"; cpu_system_counter = %"PRIi64"; "
+            "io_rchar = %"PRIi64"; io_wchar = %"PRIi64"; "
+            "io_syscr = %"PRIi64"; io_syscw = %"PRIi64";",
+            instance_name, num_proc, num_lwp,
+            vmem_size, vmem_rss,
+            vmem_data, vmem_code,
+            vmem_minflt_counter, vmem_majflt_counter,
+            cpu_user_counter, cpu_system_counter,
+            io_rchar, io_wchar, io_syscr, io_syscw);
+} /* void ps_submit_proc_list */
+
+#undef MAX_VALUE_LIST_SIZE
+
+
+static void ps_submit_procstat_entry (const char *instance_name,
+        procstat_entry_t *entry)
+{
+    char commandline[CMDLINE_BUFFER_SIZE];
+    const char *cmd_line_to_use;
+    char pid[32];
+    char *command;
+    char *owner;
+
+    cmd_line_to_use = ps_get_cmdline(entry->id, NULL, commandline,
+        sizeof(commandline));
+    if (cmd_line_to_use == NULL) {
+        // No command line. Probably a kernel process?
+        return;
+    }
+    snprintf(pid, sizeof(pid), "%lu", entry->id);
+    owner = ps_get_owner(entry->id);
+    command = ps_get_command(entry->id);
+
+    ps_submit_proc_stats (
+            MODE_DETAIL,
+            instance_name,
+            pid,
+            owner,
+            command,
+            cmd_line_to_use,
+            entry->num_proc,
+            entry->num_lwp,
+            entry->vmem_size,
+            entry->vmem_rss,
+            entry->vmem_data,
+            entry->vmem_code,
+            entry->stack_size,
+            entry->cpu_user_counter,
+            entry->cpu_system_counter,
+            entry->vmem_minflt_counter,
+            entry->vmem_majflt_counter,
+            entry->io_rchar,
+            entry->io_wchar,
+            entry->io_syscr,
+            entry->io_syscw);
+
+    sfree (command);
+    sfree (owner);
+}
+
 static void ps_submit_proc_list (procstat_t *ps)
 {
-	value_t values[2];
-	value_list_t vl = VALUE_LIST_INIT;
+    ps_submit_proc_stats (MODE_GROUP,
+            ps->name,
+            NULL,  // pid
+            NULL,  // owner
+            NULL,  // command
+            NULL,  // command_line
+            ps->num_proc,
+            ps->num_lwp,
+            ps->vmem_size,
+            ps->vmem_rss,
+            ps->vmem_data,
+            ps->vmem_code,
+            ps->stack_size,
+            ps->cpu_user_counter,
+            ps->cpu_system_counter,
+            ps->vmem_minflt_counter,
+            ps->vmem_majflt_counter,
+            ps->io_rchar,
+            ps->io_wchar,
+            ps->io_syscr,
+            ps->io_syscw);
 
-	vl.values = values;
-	vl.values_len = 2;
-	sstrncpy (vl.host, hostname_g, sizeof (vl.host));
-	sstrncpy (vl.plugin, "processes", sizeof (vl.plugin));
-	sstrncpy (vl.plugin_instance, ps->name, sizeof (vl.plugin_instance));
-
-	sstrncpy (vl.type, "ps_vm", sizeof (vl.type));
-	vl.values[0].gauge = ps->vmem_size;
-	vl.values_len = 1;
-	plugin_dispatch_values (&vl);
-
-	sstrncpy (vl.type, "ps_rss", sizeof (vl.type));
-	vl.values[0].gauge = ps->vmem_rss;
-	vl.values_len = 1;
-	plugin_dispatch_values (&vl);
-
-	sstrncpy (vl.type, "ps_data", sizeof (vl.type));
-	vl.values[0].gauge = ps->vmem_data;
-	vl.values_len = 1;
-	plugin_dispatch_values (&vl);
-
-	sstrncpy (vl.type, "ps_code", sizeof (vl.type));
-	vl.values[0].gauge = ps->vmem_code;
-	vl.values_len = 1;
-	plugin_dispatch_values (&vl);
-
-	sstrncpy (vl.type, "ps_stacksize", sizeof (vl.type));
-	vl.values[0].gauge = ps->stack_size;
-	vl.values_len = 1;
-	plugin_dispatch_values (&vl);
-
-	sstrncpy (vl.type, "ps_cputime", sizeof (vl.type));
-	vl.values[0].derive = ps->cpu_user_counter;
-	vl.values[1].derive = ps->cpu_system_counter;
-	vl.values_len = 2;
-	plugin_dispatch_values (&vl);
-
-	sstrncpy (vl.type, "ps_count", sizeof (vl.type));
-	vl.values[0].gauge = ps->num_proc;
-	vl.values[1].gauge = ps->num_lwp;
-	vl.values_len = 2;
-	plugin_dispatch_values (&vl);
-
-	sstrncpy (vl.type, "ps_pagefaults", sizeof (vl.type));
-	vl.values[0].derive = ps->vmem_minflt_counter;
-	vl.values[1].derive = ps->vmem_majflt_counter;
-	vl.values_len = 2;
-	plugin_dispatch_values (&vl);
-
-	if ( (ps->io_rchar != -1) && (ps->io_wchar != -1) )
-	{
-		sstrncpy (vl.type, "ps_disk_octets", sizeof (vl.type));
-		vl.values[0].derive = ps->io_rchar;
-		vl.values[1].derive = ps->io_wchar;
-		vl.values_len = 2;
-		plugin_dispatch_values (&vl);
-	}
-
-	if ( (ps->io_syscr != -1) && (ps->io_syscw != -1) )
-	{
-		sstrncpy (vl.type, "ps_disk_ops", sizeof (vl.type));
-		vl.values[0].derive = ps->io_syscr;
-		vl.values[1].derive = ps->io_syscw;
-		vl.values_len = 2;
-		plugin_dispatch_values (&vl);
-	}
-
-	DEBUG ("name = %s; num_proc = %lu; num_lwp = %lu; "
-			"vmem_size = %lu; vmem_rss = %lu; vmem_data = %lu; "
-			"vmem_code = %lu; "
-			"vmem_minflt_counter = %"PRIi64"; vmem_majflt_counter = %"PRIi64"; "
-			"cpu_user_counter = %"PRIi64"; cpu_system_counter = %"PRIi64"; "
-			"io_rchar = %"PRIi64"; io_wchar = %"PRIi64"; "
-			"io_syscr = %"PRIi64"; io_syscw = %"PRIi64";",
-			ps->name, ps->num_proc, ps->num_lwp,
-			ps->vmem_size, ps->vmem_rss,
-			ps->vmem_data, ps->vmem_code,
-			ps->vmem_minflt_counter, ps->vmem_majflt_counter,
-			ps->cpu_user_counter, ps->cpu_system_counter,
-			ps->io_rchar, ps->io_wchar, ps->io_syscr, ps->io_syscw);
-} /* void ps_submit_proc_list */
+    if (some_mode_configured_to_detail_g) {
+        procstat_entry_t *entry;
+        for (entry = ps->instances; entry != NULL; entry = entry->next)
+        {
+            ps_submit_procstat_entry (ps->name, entry);
+        }
+    }
+}
 
 #if KERNEL_LINUX || KERNEL_SOLARIS
 static void ps_submit_fork_rate (derive_t value)
@@ -1141,6 +1345,63 @@ static char *ps_get_cmdline (pid_t pid, char *name, char *buf, size_t buf_len)
 	}
 	return buf;
 } /* char *ps_get_cmdline (...) */
+
+static char *ps_get_command(pid_t pid)
+{
+    char *result = NULL;
+    char file_name[128];
+    FILE *f = NULL;
+    size_t line_size = 0;
+
+    snprintf(file_name, sizeof(file_name), "/proc/%d/comm", pid);
+    f = fopen(file_name, "r");
+    if (f)
+    {
+        getline (&result, &line_size, f);
+        fclose (f);
+    }
+    return result;
+}
+
+static char *ps_get_owner(pid_t pid)
+{
+    char *result = NULL;
+    char file_name[128];
+    FILE *f = NULL;
+    char *line = NULL;
+    size_t line_size = 0;
+
+    snprintf (file_name, sizeof(file_name), "/proc/%d/status", pid);
+    f = fopen (file_name, "r");
+    if (!f)
+    {
+        return NULL;
+    }
+    while (1) {
+        struct passwd passwd;
+        struct passwd *passwd_result;
+        char passwd_buffer[16384];
+        int uid;
+
+        if (getline (&line, &line_size, f) < 0)
+        {
+            break;
+        }
+        if (strncmp (line, "Uid:", 4) != 0)
+        {
+            continue;
+        }
+        uid = atoi (line + 5);
+        getpwuid_r (uid, &passwd, passwd_buffer, sizeof(passwd_buffer),
+                &passwd_result);
+        result = sstrdup (passwd_result->pw_name);
+        break;
+    }
+
+    sfree (line);
+    fclose (f);
+    return result;
+}
 
 static int read_fork_rate ()
 {


### PR DESCRIPTION
The additional data is


metadata key | description
------------------ | ---------------
```processes:pid``` | pid of the process
```processes:owner``` | process owner (note 1)
```processes:command``` | command (from ```proc/$PID/comm```)
```processes:command_line``` | command line (from ```proc/$PID/cmdline```)

**Note 1**: Owner is obtained by getting the ```Uid``` line of ```/proc/$PID/status``` and then feeding that number to ```getpwnam_r```, and than pulling out the ```pw_name``` field.

Note that the PID is sent as a string type, not a numeric type. If we want the ingestion side to take in numeric types, there would have to be additional changes on the ingestion side. (*Do we want to do this?* I don't know offhand if Monarch likes numeric labels)

**Configuration:**

Statistics are configured to be either a "summary" or a "detail" statistic on a per-stat basis. This excerpt from my config file should show what I mean:

```
<Plugin "processes">
  ProcessMatch "all" ".*"
  Detail "ps_vm"
  Detail "ps_cputime"
</Plugin>
```

The existing ```ProcessMatch``` directive is IMO the easiest way to see all processes. In this directive, every process will match the regex ```.*```, and they will all come in with ```plugin_instance``` set to "all".

The new ```Detail``` directive indicates that for ```ps_vm``` and ```ps_cputime``` we want detailed statistics (including metadata), not rolled-up summary statistics.