### PR TITLE
'df' plugin: report unrecognized config keys to the error log.

### DIFF
--- a/src/df.c
+++ b/src/df.c
@@ -153,7 +153,7 @@ static int df_config (const char *key, const char *value)
 
 		return (0);
 	}
-
+	WARNING ("df plugin: Ignoring config key '%s'", key);
 	return (-1);
 }
 


### PR DESCRIPTION
Another small cleanup. I will be proposing this upstream.