### PR TITLE
Modify the -T command line option so it watches for more errors.

### DIFF
--- a/src/daemon/collectd.c
+++ b/src/daemon/collectd.c
@@ -325,9 +325,7 @@ static int do_init (void)
 	}
 #endif
 
-	plugin_init_all ();
-
-	return (0);
+	return plugin_init_all ();
 } /* int do_init () */
 
 
@@ -381,8 +379,7 @@ static int do_loop (void)
 
 static int do_shutdown (void)
 {
-	plugin_shutdown_all ();
-	return (0);
+	return plugin_shutdown_all ();
 } /* int do_shutdown */
 
 #if COLLECT_DAEMON
@@ -691,12 +688,19 @@ int main (int argc, char **argv)
 	/*
 	 * run the actual loops
 	 */
-	do_init ();
+	if (do_init () != 0)
+	{
+		ERROR ("Error: one or more plugin init callbacks failed.");
+		exit_status = 1;
+	}
 
 	if (test_readall)
 	{
 		if (plugin_read_all_once () != 0)
+		{
+			ERROR ("Error: one or more plugin read callbacks failed.");
 			exit_status = 1;
+		}
 	}
 	else
 	{
@@ -707,7 +711,11 @@ int main (int argc, char **argv)
 	/* close syslog */
 	INFO ("Exiting normally.");
 
-	do_shutdown ();
+	if (do_shutdown () != 0)
+	{
+		ERROR ("Error: one or more plugin shutdown callbacks failed.");
+		exit_status = 1;
+	}
 
 #if COLLECT_DAEMON
 	if (daemonize)

--- a/src/daemon/configfile.c
+++ b/src/daemon/configfile.c
@@ -350,7 +350,7 @@ static int dispatch_value_plugin (const char *plugin, oconfig_item_t *ci)
 
 static int dispatch_value (const oconfig_item_t *ci)
 {
-	int ret = -2;
+	int ret = 0;
 	int i;
 
 	for (i = 0; i < cf_value_map_num; i++)
@@ -1103,6 +1103,7 @@ int cf_read (char *filename)
 {
 	oconfig_item_t *conf;
 	int i;
+	int ret = 0;
 
 	conf = cf_read_generic (filename, /* pattern = */ NULL, /* depth = */ 0);
 	if (conf == NULL)
@@ -1120,18 +1121,27 @@ int cf_read (char *filename)
 	for (i = 0; i < conf->children_num; i++)
 	{
 		if (conf->children[i].children == NULL)
-			dispatch_value (conf->children + i);
+		{
+			if (dispatch_value (conf->children + i) != 0)
+				ret = -1;
+		}
 		else
-			dispatch_block (conf->children + i);
+		{
+			if (dispatch_block (conf->children + i) != 0)
+				ret = -1;
+		}
 	}
 
 	oconfig_free (conf);
 
 	/* Read the default types.db if no `TypesDB' option was given. */
 	if (cf_default_typesdb)
-		read_types_list (PKGDATADIR"/types.db");
+	{
+		if (read_types_list (PKGDATADIR"/types.db") != 0)
+			ret = -1;
+	}
 
-	return (0);
+	return ret;
 } /* int cf_read */
 
 /* Assures the config option is a string, duplicates it and returns the copy in

--- a/src/daemon/plugin.h
+++ b/src/daemon/plugin.h
@@ -238,10 +238,10 @@ void plugin_set_dir (const char *dir);
  */
 int plugin_load (const char *name, uint32_t flags);
 
-void plugin_init_all (void);
+int plugin_init_all (void);
 void plugin_read_all (void);
 int plugin_read_all_once (void);
-void plugin_shutdown_all (void);
+int plugin_shutdown_all (void);
 
 /*
  * NAME


### PR DESCRIPTION
After this change, the following kinds of errors will cause collectd -T to
exit with an abnormal status:
- errors reading the config file
- errors reading types.db
- errors on plugin_init
- errors on plugin_shutdown