### PR TITLE
Check success of getpwuid_r before using its result.

### DIFF
--- a/src/processes.c
+++ b/src/processes.c
@@ -1404,7 +1404,8 @@ static char *ps_get_owner(pid_t pid)
         uid = atoi (line + 5);
         getpwuid_r (uid, &passwd, passwd_buffer, sizeof(passwd_buffer),
                 &passwd_result);
-        result = sstrdup (passwd_result->pw_name);
+        if (passwd_result)
+            result = sstrdup (passwd_result->pw_name);
         break;
     }
 


### PR DESCRIPTION
It can happen that ```/proc/$PID/status``` can return a Uid that ```getpwuid_r```
can't resolve. One notable scenario is when using Docker, as discussed here.

https://groups.google.com/forum/?utm_medium=email&utm_source=footer#!msg/gc-monitoring-beta-discussion/usp1iaInChg/Ds2tgpLmGQAJ
