### PR TITLE
Bump queue drop size to 100k; add debug logging when dropping points.

### DIFF
--- a/src/write_gcm.c
+++ b/src/write_gcm.c
@@ -117,7 +117,7 @@ static _Bool wg_some_error_occured_g = 0;
 // so that we cam always try to send a valid JSON message.
 
 // The "soft target" for the max size of our json messages.
-#define JSON_SOFT_TARGET_SIZE 64000
+#define JSON_SOFT_TARGET_SIZE 512000
 
 // The maximum size of the project id (platform-defined).
 #define MAX_PROJECT_ID_SIZE ((size_t) 64)


### PR DESCRIPTION
Adding the new agent metric to track dropped points is more involved and will be done in a separate PR.
@dhrupadb FYI.
