### PR TITLE
Restart Consumer thread in case of non-shutdown thread exit.

### DIFF
--- a/src/write_gcm.c
+++ b/src/write_gcm.c
@@ -3580,7 +3580,7 @@ static void *wg_process_queue(wg_context_t *ctx, wg_queue_t *queue,
     queue->consumer_thread_created = 0;
     ERROR("write_gcm: Consumer thread unexpectedly exiting.");
   } else {
-      WARNING("write_gcm: Consumer thread is exiting due to agent shutdown.");
+      WARNING("write_gcm: Consumer thread is shutting down.");
   }
   return NULL;
 }

--- a/src/write_gcm.c
+++ b/src/write_gcm.c
@@ -3580,7 +3580,7 @@ static void *wg_process_queue(wg_context_t *ctx, wg_queue_t *queue,
     queue->consumer_thread_created = 0;
     ERROR("write_gcm: Consumer thread unexpectedly exiting.");
   } else {
-      WARNING("write_gcm: Consumer thread is shutting down.");
+    WARNING("write_gcm: Consumer thread is shutting down.");
   }
   return NULL;
 }

--- a/src/write_gcm.c
+++ b/src/write_gcm.c
@@ -3568,7 +3568,7 @@ static void *wg_process_queue(wg_context_t *ctx, wg_queue_t *queue,
     }
     if (wg_update_stats(stats) != 0) {
       wg_some_error_occured_g = 1;
-      WARNING("%s: wg_update_stats failed.", this_plugin_name);
+      ERROR("%s: wg_update_stats failed.", this_plugin_name);
       break;
     }
     payloads = NULL;
@@ -3576,7 +3576,12 @@ static void *wg_process_queue(wg_context_t *ctx, wg_queue_t *queue,
 
  leave:
   wg_deriv_tree_destroy(deriv_tree);
-  WARNING("write_gcm: Consumer thread is exiting.");
+  if (queue->request_terminate == 0) {
+    queue->consumer_thread_created = 0;
+    ERROR("write_gcm: Consumer thread is exiting.");
+  } else {
+    WARNING("write_gcm: Consumer thread is exiting.");
+  }
   return NULL;
 }
 

--- a/src/write_gcm.c
+++ b/src/write_gcm.c
@@ -3576,11 +3576,11 @@ static void *wg_process_queue(wg_context_t *ctx, wg_queue_t *queue,
 
  leave:
   wg_deriv_tree_destroy(deriv_tree);
-  if (queue->request_terminate == 0) {
+  if (!queue->request_terminate) {
     queue->consumer_thread_created = 0;
-    ERROR("write_gcm: Consumer thread is exiting.");
+    ERROR("write_gcm: Consumer thread unexpectedly exiting.");
   } else {
-    WARNING("write_gcm: Consumer thread is exiting.");
+      WARNING("write_gcm: Consumer thread is exiting due to agent shutdown.");
   }
   return NULL;
 }


### PR DESCRIPTION
Changed error logging for read thread. Set thread created to 0 in case of unnatural exit (e.g. OOM)