### PR TITLE
GCP metadata logging cleanup

### DIFF
--- a/src/write_gcm.c
+++ b/src/write_gcm.c
@@ -509,7 +509,7 @@ static EVP_PKEY *wg_credential_contex_load_pkey(char const *filename,
 // Otherwise returns 0.
 static int wg_curl_get_or_post(char *response_buffer,
     size_t response_buffer_size, const char *url, const char *body,
-    const char **headers, int num_headers);
+    const char **headers, int num_headers, _Bool expect_failure);
 
 //------------------------------------------------------------------------------
 // Private implementation starts here.
@@ -524,7 +524,7 @@ static size_t wg_curl_write_callback(char *ptr, size_t size, size_t nmemb,
 
 static int wg_curl_get_or_post(char *response_buffer,
     size_t response_buffer_size, const char *url, const char *body,
-    const char **headers, int num_headers) {
+    const char **headers, int num_headers, _Bool expect_failure) {
   DEBUG("write_gcm: Doing %s request: url %s, body %s, num_headers %d",
         body == NULL ? "GET" : "POST",
         url, body, num_headers);
@@ -574,8 +574,10 @@ static int wg_curl_get_or_post(char *response_buffer,
   curl_result = curl_easy_getinfo(curl, CURLINFO_RESPONSE_CODE, &response_code);
   write_ctx.data[0] = 0;
   if (response_code >= 400) {
-    WARNING("write_gcm: Unsuccessful HTTP request %ld: %s",
-            response_code, response_buffer);
+    if (!expect_failure) {
+      WARNING("write_gcm: Unsuccessful HTTP request %ld: %s",
+              response_code, response_buffer);
+    }
     result = -2;
     goto leave;
   }
@@ -1093,7 +1095,7 @@ static int wg_oauth2_talk_to_server_and_store_result(oauth2_ctx_t *ctx,
     cdtime_t now) {
   char response[2048];
   if (wg_curl_get_or_post(response, sizeof(response), url, body,
-      headers, num_headers) != 0) {
+      headers, num_headers, 0) != 0) {
     return -1;
   }
 
@@ -2101,16 +2103,16 @@ static monitored_resource_t *wg_monitored_resource_create_for_aws(
 
 // Fetch 'resource' from the GCP metadata server.
 static char *wg_get_from_gcp_metadata_server(const char *resource,
-    _Bool ignore_failure);
+    _Bool expect_faiilure);
 
 // Fetch 'resource' from the AWS metadata server.
 static char *wg_get_from_aws_metadata_server(const char *resource,
-    _Bool ignore_failure);
+    _Bool expect_faiilure);
 
 // Fetches a resource (defined by the concatenation of 'base' and 'resource')
 // from an AWS or GCE metadata server and returns it. Returns NULL upon error.
 static char *wg_get_from_metadata_server(const char *base, const char *resource,
-    const char **headers, int num_headers, _Bool ignore_failure);
+    const char **headers, int num_headers, _Bool expect_faiilure);
 
 static char * detect_cloud_provider() {
   char * gcp_hostname = wg_get_from_gcp_metadata_server("instance/hostname", 1);
@@ -2395,21 +2397,21 @@ static monitored_resource_t *wg_monitored_resource_create_for_aws(
 }
 
 static char *wg_get_from_gcp_metadata_server(const char *resource,
-    _Bool ignore_failure) {
+    _Bool expect_faiilure) {
   const char *headers[] = { gcp_metadata_header };
   return wg_get_from_metadata_server(
       "http://169.254.169.254/computeMetadata/v1beta1/", resource,
-      headers, STATIC_ARRAY_SIZE(headers), ignore_failure);
+      headers, STATIC_ARRAY_SIZE(headers), expect_faiilure);
 }
 
 static char *wg_get_from_aws_metadata_server(const char *resource,
-    _Bool ignore_failure) {
+    _Bool expect_faiilure) {
   return wg_get_from_metadata_server(
-      "http://169.254.169.254/latest/", resource, NULL, 0, ignore_failure);
+      "http://169.254.169.254/latest/", resource, NULL, 0, expect_faiilure);
 }
 
 static char *wg_get_from_metadata_server(const char *base, const char *resource,
-    const char **headers, int num_headers, _Bool ignore_failure) {
+    const char **headers, int num_headers, _Bool expect_faiilure) {
   char url[256];
   int result = snprintf(url, sizeof(url), "%s%s", base, resource);
   if (result < 0 || result >= sizeof(url)) {
@@ -2419,8 +2421,8 @@ static char *wg_get_from_metadata_server(const char *base, const char *resource,
 
   char buffer[2048];
   if (wg_curl_get_or_post(buffer, sizeof(buffer), url, NULL, headers,
-      num_headers) != 0) {
-    if (!ignore_failure) {
+      num_headers, expect_faiilure) != 0) {
+    if (!expect_faiilure) {
       ERROR("write_gcm: wg_get_from_metadata_server failed to fetch metadata"
             "from %s", url);
     }
@@ -3840,7 +3842,7 @@ static int wg_transmit_unique_segment(const wg_context_t *ctx,
 
       int wg_result = wg_curl_get_or_post(response, sizeof(response),
         ctx->agent_translation_service_url, json,
-        headers, STATIC_ARRAY_SIZE(headers));
+        headers, STATIC_ARRAY_SIZE(headers), 0);
       if (wg_result != 0) {
         wg_log_json_message(ctx, "Error %d from wg_curl_get_or_post\n",
                             wg_result);
@@ -3881,7 +3883,7 @@ static int wg_transmit_unique_segment(const wg_context_t *ctx,
 
         if (wg_curl_get_or_post(response, sizeof(response),
             ctx->custom_metrics_url, json,
-            headers, STATIC_ARRAY_SIZE(headers)) != 0) {
+            headers, STATIC_ARRAY_SIZE(headers), 0) != 0) {
           wg_log_json_message(ctx, "Error contacting server.\n");
           ERROR("write_gcm: Error talking to the endpoint.");
           ++ctx->gsd_stats->api_connectivity_failures;

--- a/src/write_gcm.c
+++ b/src/write_gcm.c
@@ -2426,7 +2426,6 @@ static char *wg_get_from_metadata_server(const char *base, const char *resource,
     }
     return NULL;
   }
-
   return sstrdup(buffer);
 }
 

--- a/src/write_gcm.c
+++ b/src/write_gcm.c
@@ -2108,7 +2108,7 @@ static char *wg_get_from_aws_metadata_server(const char *resource);
 // Fetches a resource (defined by the concatenation of 'base' and 'resource')
 // from an AWS or GCE metadata server and returns it. Returns NULL upon error.
 static char *wg_get_from_metadata_server(const char *base, const char *resource,
-    const char **headers, int num_headers);
+    const char **headers, int num_headers, const char *provider);
 
 static char * detect_cloud_provider() {
   char * gcp_hostname = wg_get_from_gcp_metadata_server("instance/hostname");

--- a/src/write_gcm.c
+++ b/src/write_gcm.c
@@ -2251,7 +2251,7 @@ static monitored_resource_t *wg_monitored_resource_create_for_gcp(
   // metadata server.
   if (project_id_to_use == NULL) {
     // This gets the string id of the project (not the numeric id).
-    project_id_to_use = wg_get_from_gcp_metadata_server("project/project-id");
+    project_id_to_use = wg_get_from_gcp_metadata_server("project/project-id", 0);
     if (project_id_to_use == NULL) {
       ERROR("write_gcm: Can't get project ID from GCP metadata server "
           " (and 'Project' not specified in the config file).");
@@ -2261,7 +2261,7 @@ static monitored_resource_t *wg_monitored_resource_create_for_gcp(
 
   if (instance_id_to_use == NULL) {
     // This gets the numeric instance id.
-    instance_id_to_use = wg_get_from_gcp_metadata_server("instance/id");
+    instance_id_to_use = wg_get_from_gcp_metadata_server("instance/id", 0);
     if (instance_id_to_use == NULL) {
       ERROR("write_gcm: Can't get instance ID from GCP metadata server "
           " (and 'Instance' not specified in the config file).");
@@ -2272,7 +2272,7 @@ static monitored_resource_t *wg_monitored_resource_create_for_gcp(
   if (zone_to_use == NULL) {
     // This gets the zone.
     char *verbose_zone =
-        wg_get_from_gcp_metadata_server("instance/zone");
+        wg_get_from_gcp_metadata_server("instance/zone", 0);
     if (verbose_zone == NULL) {
       ERROR("write_gcm: Can't get zone ID from GCP metadata server "
           " (and 'Zone' not specified in the config file).");
@@ -2334,7 +2334,7 @@ static monitored_resource_t *wg_monitored_resource_create_for_aws(
   if (region_to_use == NULL || instance_id_to_use == NULL ||
       account_id_to_use == NULL) {
     iid_document = wg_get_from_aws_metadata_server(
-        "dynamic/instance-identity/document");
+        "dynamic/instance-identity/document", 0);
     if (iid_document == NULL) {
       ERROR("write_gcm: Can't get dynamic data from metadata server");
       goto leave;
@@ -2421,8 +2421,8 @@ static char *wg_get_from_metadata_server(const char *base, const char *resource,
   if (wg_curl_get_or_post(buffer, sizeof(buffer), url, NULL, headers,
       num_headers) != 0) {
     if (!ignore_failure) {
-      INFO("write_gcm: wg_get_from_metadata_server failed to fetch %s metadata "
-         "from %s", provider, url);
+      ERROR("write_gcm: wg_get_from_metadata_server failed to fetch metadata"
+            "from %s", url);
     }
     return NULL;
   }

--- a/src/write_gcm.c
+++ b/src/write_gcm.c
@@ -2103,16 +2103,16 @@ static monitored_resource_t *wg_monitored_resource_create_for_aws(
 
 // Fetch 'resource' from the GCP metadata server.
 static char *wg_get_from_gcp_metadata_server(const char *resource,
-    _Bool expect_faiilure);
+    _Bool expect_failure);
 
 // Fetch 'resource' from the AWS metadata server.
 static char *wg_get_from_aws_metadata_server(const char *resource,
-    _Bool expect_faiilure);
+    _Bool expect_failure);
 
 // Fetches a resource (defined by the concatenation of 'base' and 'resource')
 // from an AWS or GCE metadata server and returns it. Returns NULL upon error.
 static char *wg_get_from_metadata_server(const char *base, const char *resource,
-    const char **headers, int num_headers, _Bool expect_faiilure);
+    const char **headers, int num_headers, _Bool expect_failure);
 
 static char * detect_cloud_provider() {
   char * gcp_hostname = wg_get_from_gcp_metadata_server("instance/hostname", 1);
@@ -2397,21 +2397,21 @@ static monitored_resource_t *wg_monitored_resource_create_for_aws(
 }
 
 static char *wg_get_from_gcp_metadata_server(const char *resource,
-    _Bool expect_faiilure) {
+    _Bool expect_failure) {
   const char *headers[] = { gcp_metadata_header };
   return wg_get_from_metadata_server(
       "http://169.254.169.254/computeMetadata/v1beta1/", resource,
-      headers, STATIC_ARRAY_SIZE(headers), expect_faiilure);
+      headers, STATIC_ARRAY_SIZE(headers), expect_failure);
 }
 
 static char *wg_get_from_aws_metadata_server(const char *resource,
-    _Bool expect_faiilure) {
+    _Bool expect_failure) {
   return wg_get_from_metadata_server(
-      "http://169.254.169.254/latest/", resource, NULL, 0, expect_faiilure);
+      "http://169.254.169.254/latest/", resource, NULL, 0, expect_failure);
 }
 
 static char *wg_get_from_metadata_server(const char *base, const char *resource,
-    const char **headers, int num_headers, _Bool expect_faiilure) {
+    const char **headers, int num_headers, _Bool expect_failure) {
   char url[256];
   int result = snprintf(url, sizeof(url), "%s%s", base, resource);
   if (result < 0 || result >= sizeof(url)) {
@@ -2421,8 +2421,8 @@ static char *wg_get_from_metadata_server(const char *base, const char *resource,
 
   char buffer[2048];
   if (wg_curl_get_or_post(buffer, sizeof(buffer), url, NULL, headers,
-      num_headers, expect_faiilure) != 0) {
-    if (!expect_faiilure) {
+      num_headers, expect_failure) != 0) {
+    if (!expect_failure) {
       ERROR("write_gcm: wg_get_from_metadata_server failed to fetch metadata"
             "from %s", url);
     }


### PR DESCRIPTION
Make logs more informative when running on AWS. As GCP gets checked first, customers may interpret the message from the metadata server as an error.