### PR TITLE
Updating metadata api version to use v1 instead of v1beta1.

### DIFF
--- a/src/write_gcm.c
+++ b/src/write_gcm.c
@@ -847,7 +847,7 @@ int wg_extract_toplevel_json_long_long(const char *json, const char *key,
 // THE EASY ROUTE
 //
 // Make a GET request to the metadata server at the following URL:
-// http://169.254.169.254/computeMetadata/v1beta1/instance/service-accounts/default/token
+// http://169.254.169.254/computeMetadata/v1/instance/service-accounts/default/token
 //
 // If our call is successful, the server will respond with a json object looking
 // like this:
@@ -983,7 +983,7 @@ static int wg_oauth2_get_auth_header_nolock(oauth2_ctx_t *ctx,
     const credential_ctx_t *cred_ctx) {
   // The URL to get the auth token from the metadata server.
   static const char gcp_metadata_fetch_auth_token[] =
-    "http://169.254.169.254/computeMetadata/v1beta1/instance/service-accounts/default/token";
+    "http://169.254.169.254/computeMetadata/v1/instance/service-accounts/default/token";
 
   cdtime_t now = cdtime();
   // Try to reuse an existing token. We build in a minute of slack in order to
@@ -2400,7 +2400,7 @@ static char *wg_get_from_gcp_metadata_server(const char *resource,
     _Bool silent_failures) {
   const char *headers[] = { gcp_metadata_header };
   return wg_get_from_metadata_server(
-      "http://169.254.169.254/computeMetadata/v1beta1/", resource,
+      "http://169.254.169.254/computeMetadata/v1/", resource,
       headers, STATIC_ARRAY_SIZE(headers), silent_failures);
 }
 


### PR DESCRIPTION
According the the Metadata API documentation, the current version is v1, so we should update our code accordingly.

https://cloud.google.com/compute/docs/storing-retrieving-metadata