### PR TITLE
Adding a procstat_data_t struct to represent shared procstat data.

### DIFF
--- a/src/processes.c
+++ b/src/processes.c
@@ -159,7 +159,7 @@
 # endif
 #endif
 
-typedef struct {
+typedef struct procstat_data_s {
 	unsigned long num_proc;
 	unsigned long num_lwp;
 	unsigned long vmem_size;
@@ -197,7 +197,7 @@ typedef struct procstat_entry_s
 	unsigned long cpu_user;
 	unsigned long cpu_system;
 
-	procstat_data_t procstat_data;
+	procstat_data_t data;
 
 	struct procstat_entry_s *next;
 } procstat_entry_t;
@@ -210,7 +210,7 @@ typedef struct procstat
 	regex_t *re;
 #endif
 
-	procstat_data_t procstat_data;
+	procstat_data_t data;
 
 	struct procstat   *next;
 	struct procstat_entry_s *instances;
@@ -431,60 +431,60 @@ static void ps_list_add (const char *name, const char *cmdline, procstat_entry_t
 		}
 
 		pse->age = 0;
-		pse->procstat_data.num_proc   = entry->procstat_data.num_proc;
-		pse->procstat_data.num_lwp    = entry->procstat_data.num_lwp;
-		pse->procstat_data.vmem_size  = entry->procstat_data.vmem_size;
-		pse->procstat_data.vmem_rss   = entry->procstat_data.vmem_rss;
-		pse->procstat_data.vmem_data  = entry->procstat_data.vmem_data;
-		pse->procstat_data.vmem_code  = entry->procstat_data.vmem_code;
-		pse->procstat_data.stack_size = entry->procstat_data.stack_size;
-		pse->procstat_data.io_rchar   = entry->procstat_data.io_rchar;
-		pse->procstat_data.io_wchar   = entry->procstat_data.io_wchar;
-		pse->procstat_data.io_syscr   = entry->procstat_data.io_syscr;
-		pse->procstat_data.io_syscw   = entry->procstat_data.io_syscw;
-		pse->procstat_data.io_diskr   = entry->procstat_data.io_diskr;
-		pse->procstat_data.io_diskw   = entry->procstat_data.io_diskw;
-		pse->procstat_data.cswitch_vol   = entry->procstat_data.cswitch_vol;
-		pse->procstat_data.cswitch_invol = entry->procstat_data.cswitch_invol;
+		pse->data.num_proc   = entry->data.num_proc;
+		pse->data.num_lwp    = entry->data.num_lwp;
+		pse->data.vmem_size  = entry->data.vmem_size;
+		pse->data.vmem_rss   = entry->data.vmem_rss;
+		pse->data.vmem_data  = entry->data.vmem_data;
+		pse->data.vmem_code  = entry->data.vmem_code;
+		pse->data.stack_size = entry->data.stack_size;
+		pse->data.io_rchar   = entry->data.io_rchar;
+		pse->data.io_wchar   = entry->data.io_wchar;
+		pse->data.io_syscr   = entry->data.io_syscr;
+		pse->data.io_syscw   = entry->data.io_syscw;
+		pse->data.io_diskr   = entry->data.io_diskr;
+		pse->data.io_diskw   = entry->data.io_diskw;
+		pse->data.cswitch_vol   = entry->data.cswitch_vol;
+		pse->data.cswitch_invol = entry->data.cswitch_invol;
 
-		ps->procstat_data.num_proc   += pse->procstat_data.num_proc;
-		ps->procstat_data.num_lwp    += pse->procstat_data.num_lwp;
-		ps->procstat_data.vmem_size  += pse->procstat_data.vmem_size;
-		ps->procstat_data.vmem_rss   += pse->procstat_data.vmem_rss;
-		ps->procstat_data.vmem_data  += pse->procstat_data.vmem_data;
-		ps->procstat_data.vmem_code  += pse->procstat_data.vmem_code;
-		ps->procstat_data.stack_size += pse->procstat_data.stack_size;
+		ps->data.num_proc   += pse->data.num_proc;
+		ps->data.num_lwp    += pse->data.num_lwp;
+		ps->data.vmem_size  += pse->data.vmem_size;
+		ps->data.vmem_rss   += pse->data.vmem_rss;
+		ps->data.vmem_data  += pse->data.vmem_data;
+		ps->data.vmem_code  += pse->data.vmem_code;
+		ps->data.stack_size += pse->data.stack_size;
 
-		ps->procstat_data.io_rchar   += ((pse->procstat_data.io_rchar == -1)?0:pse->procstat_data.io_rchar);
-		ps->procstat_data.io_wchar   += ((pse->procstat_data.io_wchar == -1)?0:pse->procstat_data.io_wchar);
-		ps->procstat_data.io_syscr   += ((pse->procstat_data.io_syscr == -1)?0:pse->procstat_data.io_syscr);
-		ps->procstat_data.io_syscw   += ((pse->procstat_data.io_syscw == -1)?0:pse->procstat_data.io_syscw);
-		ps->procstat_data.io_diskr   += ((pse->procstat_data.io_diskr == -1)?0:pse->procstat_data.io_diskr);
-		ps->procstat_data.io_diskw   += ((pse->procstat_data.io_diskw == -1)?0:pse->procstat_data.io_diskw);
+		ps->data.io_rchar   += ((pse->data.io_rchar == -1)?0:pse->data.io_rchar);
+		ps->data.io_wchar   += ((pse->data.io_wchar == -1)?0:pse->data.io_wchar);
+		ps->data.io_syscr   += ((pse->data.io_syscr == -1)?0:pse->data.io_syscr);
+		ps->data.io_syscw   += ((pse->data.io_syscw == -1)?0:pse->data.io_syscw);
+		ps->data.io_diskr   += ((pse->data.io_diskr == -1)?0:pse->data.io_diskr);
+		ps->data.io_diskw   += ((pse->data.io_diskw == -1)?0:pse->data.io_diskw);
 
-		ps->procstat_data.cswitch_vol   += ((pse->procstat_data.cswitch_vol == -1)?0:pse->procstat_data.cswitch_vol);
-		ps->procstat_data.cswitch_invol += ((pse->procstat_data.cswitch_invol == -1)?0:pse->procstat_data.cswitch_invol);
-		want_init = (entry->procstat_data.vmem_minflt_counter == 0)
-				&& (entry->procstat_data.vmem_majflt_counter == 0);
+		ps->data.cswitch_vol   += ((pse->data.cswitch_vol == -1)?0:pse->data.cswitch_vol);
+		ps->data.cswitch_invol += ((pse->data.cswitch_invol == -1)?0:pse->data.cswitch_invol);
+		want_init = (entry->data.vmem_minflt_counter == 0)
+				&& (entry->data.vmem_majflt_counter == 0);
 		ps_update_counter (want_init,
-				&ps->procstat_data.vmem_minflt_counter,
-				&pse->procstat_data.vmem_minflt_counter, &pse->vmem_minflt,
-				entry->procstat_data.vmem_minflt_counter, entry->vmem_minflt);
+				&ps->data.vmem_minflt_counter,
+				&pse->data.vmem_minflt_counter, &pse->vmem_minflt,
+				entry->data.vmem_minflt_counter, entry->vmem_minflt);
 		ps_update_counter (want_init,
-				&ps->procstat_data.vmem_majflt_counter,
-				&pse->procstat_data.vmem_majflt_counter, &pse->vmem_majflt,
-				entry->procstat_data.vmem_majflt_counter, entry->vmem_majflt);
+				&ps->data.vmem_majflt_counter,
+				&pse->data.vmem_majflt_counter, &pse->vmem_majflt,
+				entry->data.vmem_majflt_counter, entry->vmem_majflt);
 
-		want_init = (entry->procstat_data.cpu_user_counter == 0)
-				&& (entry->procstat_data.cpu_system_counter == 0);
+		want_init = (entry->data.cpu_user_counter == 0)
+				&& (entry->data.cpu_system_counter == 0);
 		ps_update_counter (want_init,
-				&ps->procstat_data.cpu_user_counter,
-				&pse->procstat_data.cpu_user_counter, &pse->cpu_user,
-				entry->procstat_data.cpu_user_counter, entry->cpu_user);
+				&ps->data.cpu_user_counter,
+				&pse->data.cpu_user_counter, &pse->cpu_user,
+				entry->data.cpu_user_counter, entry->cpu_user);
 		ps_update_counter (want_init,
-				&ps->procstat_data.cpu_system_counter,
-				&pse->procstat_data.cpu_system_counter, &pse->cpu_system,
-				entry->procstat_data.cpu_system_counter, entry->cpu_system);
+				&ps->data.cpu_system_counter,
+				&pse->data.cpu_system_counter, &pse->cpu_system,
+				entry->data.cpu_system_counter, entry->cpu_system);
 	}
 }
 
@@ -496,21 +496,21 @@ static void ps_list_reset (void)
 
 	for (procstat_t *ps = list_head_g; ps != NULL; ps = ps->next)
 	{
-		ps->procstat_data.num_proc    = 0;
-		ps->procstat_data.num_lwp     = 0;
-		ps->procstat_data.vmem_size   = 0;
-		ps->procstat_data.vmem_rss    = 0;
-		ps->procstat_data.vmem_data   = 0;
-		ps->procstat_data.vmem_code   = 0;
-		ps->procstat_data.stack_size  = 0;
-		ps->procstat_data.io_rchar = -1;
-		ps->procstat_data.io_wchar = -1;
-		ps->procstat_data.io_syscr = -1;
-		ps->procstat_data.io_syscw = -1;
-		ps->procstat_data.io_diskr = -1;
-		ps->procstat_data.io_diskw = -1;
-		ps->procstat_data.cswitch_vol   = -1;
-		ps->procstat_data.cswitch_invol = -1;
+		ps->data.num_proc    = 0;
+		ps->data.num_lwp     = 0;
+		ps->data.vmem_size   = 0;
+		ps->data.vmem_rss    = 0;
+		ps->data.vmem_data   = 0;
+		ps->data.vmem_code   = 0;
+		ps->data.stack_size  = 0;
+		ps->data.io_rchar = -1;
+		ps->data.io_wchar = -1;
+		ps->data.io_syscr = -1;
+		ps->data.io_syscw = -1;
+		ps->data.io_diskr = -1;
+		ps->data.io_diskw = -1;
+		ps->data.cswitch_vol   = -1;
+		ps->data.cswitch_invol = -1;
 
 		pse_prev = NULL;
 		pse = ps->instances;
@@ -779,7 +779,7 @@ static void ps_submit_proc_stats (
         const char *owner,
         const char *command,
         const char *command_line,
-        procstat_data_t procstat_data)
+        procstat_data_t data)
 {
     const want_detail_configuration_t *config = &want_detail_configuration_g;
     value_t values[MAX_VALUE_LIST_SIZE];
@@ -809,66 +809,66 @@ static void ps_submit_proc_stats (
         }
     }
 
-    vl.values[0].gauge = procstat_data.num_proc;
-    vl.values[1].gauge = procstat_data.num_lwp;
+    vl.values[0].gauge = data.num_proc;
+    vl.values[1].gauge = data.num_lwp;
     dispatch_value_helper(&vl, "ps_count", NULL, 2, doing_detail, config->ps_count);
 
-    vl.values[0].gauge = procstat_data.vmem_size;
+    vl.values[0].gauge = data.vmem_size;
     dispatch_value_helper(&vl, "ps_vm", NULL, 1, doing_detail, config->ps_vm);
 
-    vl.values[0].gauge = procstat_data.vmem_rss;
+    vl.values[0].gauge = data.vmem_rss;
     dispatch_value_helper(&vl, "ps_rss", NULL, 1, doing_detail, config->ps_rss);
 
-    vl.values[0].gauge = procstat_data.vmem_data;
+    vl.values[0].gauge = data.vmem_data;
     dispatch_value_helper(&vl, "ps_data", NULL, 1, doing_detail, config->ps_data);
 
-    vl.values[0].gauge = procstat_data.vmem_code;
+    vl.values[0].gauge = data.vmem_code;
     dispatch_value_helper(&vl, "ps_code", NULL, 1, doing_detail, config->ps_code);
 
-    vl.values[0].gauge = procstat_data.stack_size;
+    vl.values[0].gauge = data.stack_size;
     dispatch_value_helper(&vl, "ps_stacksize", NULL, 1, doing_detail,
                           config->ps_stacksize);
 
-    vl.values[0].derive = procstat_data.vmem_minflt_counter;
-    vl.values[1].derive = procstat_data.vmem_majflt_counter;
+    vl.values[0].derive = data.vmem_minflt_counter;
+    vl.values[1].derive = data.vmem_majflt_counter;
     dispatch_value_helper(&vl, "ps_pagefaults", NULL, 2, doing_detail,
                           config->ps_pagefaults);
 
-    vl.values[0].derive = procstat_data.cpu_user_counter;
-    vl.values[1].derive = procstat_data.cpu_system_counter;
+    vl.values[0].derive = data.cpu_user_counter;
+    vl.values[1].derive = data.cpu_system_counter;
     dispatch_value_helper(&vl, "ps_cputime", NULL, 2, doing_detail,
                           config->ps_cputime);
 
-    if ( (procstat_data.io_rchar != -1) && (procstat_data.io_wchar != -1) )
+    if ( (data.io_rchar != -1) && (data.io_wchar != -1) )
     {
-        vl.values[0].derive = procstat_data.io_rchar;
-        vl.values[1].derive = procstat_data.io_wchar;
+        vl.values[0].derive = data.io_rchar;
+        vl.values[1].derive = data.io_wchar;
         dispatch_value_helper(&vl, "io_octets", NULL, 2, doing_detail,
                 config->ps_disk_octets);
     }
 
-    if ( (procstat_data.io_syscr != -1) && (procstat_data.io_syscw != -1) )
+    if ( (data.io_syscr != -1) && (data.io_syscw != -1) )
     {
-        vl.values[0].derive = procstat_data.io_syscr;
-        vl.values[1].derive = procstat_data.io_syscw;
+        vl.values[0].derive = data.io_syscr;
+        vl.values[1].derive = data.io_syscw;
         dispatch_value_helper(&vl, "io_ops", NULL, 2, doing_detail,
                               config->ps_disk_ops);
     }
 
-    if ( (procstat_data.io_diskr != -1) && (procstat_data.io_diskw != -1) )
+    if ( (data.io_diskr != -1) && (data.io_diskw != -1) )
     {
-        vl.values[0].derive = procstat_data.io_diskr;
-        vl.values[1].derive = procstat_data.io_diskw;
+        vl.values[0].derive = data.io_diskr;
+        vl.values[1].derive = data.io_diskw;
         dispatch_value_helper(&vl, "disk_octets", NULL, 2, doing_detail,
                               config->ps_disk_octets);
     }
 
     if ( report_ctx_switch )
     {
-	    vl.values[0].derive = procstat_data.cswitch_vol;
+	    vl.values[0].derive = data.cswitch_vol;
 	    dispatch_value_helper(&vl, "contextswitch", "voluntary", 2, doing_detail,
 		    config->cswitch_vol);
-	    vl.values[0].derive = procstat_data.cswitch_invol;
+	    vl.values[0].derive = data.cswitch_invol;
 	    dispatch_value_helper(&vl, "contextswitch", "involuntary", 2, doing_detail,
 		    config->cswitch_invol);
     }
@@ -884,14 +884,14 @@ static void ps_submit_proc_stats (
             "io_syscr = %"PRIi64"; io_syscw = %"PRIi64";"
             "io_diskr = %"PRIi64"; io_diskw = %"PRIi64";"
             "cswitch_vol = %"PRIi64"; cswitch_invol = %"PRIi64";",
-            instance_name, pid, procstat_data.num_proc, procstat_data.num_lwp,
-            procstat_data.vmem_size, procstat_data.vmem_rss,
-            procstat_data.vmem_data, procstat_data.vmem_code,
-            procstat_data.vmem_minflt_counter, procstat_data.vmem_majflt_counter,
-            procstat_data.cpu_user_counter, procstat_data.cpu_system_counter,
-            procstat_data.io_rchar, procstat_data.io_wchar, procstat_data.io_syscr, procstat_data.io_syscw,
-            procstat_data.io_diskr, procstat_data.io_diskw,
-            procstat_data.cswitch_vol, procstat_data.cswitch_invol);
+            instance_name, pid, data.num_proc, data.num_lwp,
+            data.vmem_size, data.vmem_rss,
+            data.vmem_data, data.vmem_code,
+            data.vmem_minflt_counter, data.vmem_majflt_counter,
+            data.cpu_user_counter, data.cpu_system_counter,
+            data.io_rchar, data.io_wchar, data.io_syscr, data.io_syscw,
+            data.io_diskr, data.io_diskw,
+            data.cswitch_vol, data.cswitch_invol);
 } /* void ps_submit_proc_list */
 
 #undef MAX_VALUE_LIST_SIZE
@@ -923,7 +923,7 @@ static void ps_submit_procstat_entry (const char *instance_name,
             owner,
             command,
             cmd_line_to_use,
-            entry->procstat_data);
+            entry->data);
 
     sfree (command);
     sfree (owner);
@@ -938,7 +938,7 @@ static void ps_submit_proc_list (procstat_t *ps)
             NULL,  // owner
             NULL,  // command
             NULL,  // command_line
-            ps->procstat_data);
+            ps->data);
 
     if (some_detail_active_g) {
         procstat_entry_t *entry;
@@ -1048,8 +1048,8 @@ static procstat_t *ps_read_tasks_status (long pid, procstat_t *ps)
 	}
 	closedir (dh);
 
-	ps->procstat_data.cswitch_vol = cswitch_vol;
-	ps->procstat_data.cswitch_invol = cswitch_invol;
+	ps->data.cswitch_vol = cswitch_vol;
+	ps->data.cswitch_invol = cswitch_invol;
 
 	return (ps);
 } /* int *ps_read_tasks_status */
@@ -1117,10 +1117,10 @@ static procstat_t *ps_read_status (long pid, procstat_t *ps)
 				sstrerror (errno, errbuf, sizeof (errbuf)));
 	}
 
-	ps->procstat_data.vmem_data = data * 1024;
-	ps->procstat_data.vmem_code = (exe + lib) * 1024;
+	ps->data.vmem_data = data * 1024;
+	ps->data.vmem_code = (exe + lib) * 1024;
 	if (threads != 0)
-		ps->procstat_data.num_lwp = threads;
+		ps->data.num_lwp = threads;
 
 	return (ps);
 } /* procstat_t *ps_read_vmem */
@@ -1145,17 +1145,17 @@ static procstat_t *ps_read_io (long pid, procstat_t *ps)
 		char *endptr;
 
 		if (strncasecmp (buffer, "rchar:", 6) == 0)
-			val = &(ps->procstat_data.io_rchar);
+			val = &(ps->data.io_rchar);
 		else if (strncasecmp (buffer, "wchar:", 6) == 0)
-			val = &(ps->procstat_data.io_wchar);
+			val = &(ps->data.io_wchar);
 		else if (strncasecmp (buffer, "syscr:", 6) == 0)
-			val = &(ps->procstat_data.io_syscr);
+			val = &(ps->data.io_syscr);
 		else if (strncasecmp (buffer, "syscw:", 6) == 0)
-			val = &(ps->procstat_data.io_syscw);
+			val = &(ps->data.io_syscw);
 		else if (strncasecmp (buffer, "read_bytes:", 11) == 0)
-			val = &(ps->procstat_data.io_diskr);
+			val = &(ps->data.io_diskr);
 		else if (strncasecmp (buffer, "write_bytes:", 12) == 0)
-			val = &(ps->procstat_data.io_diskw);
+			val = &(ps->data.io_diskw);
 		else
 			continue;
 
@@ -1262,26 +1262,26 @@ static int ps_read_process (long pid, procstat_t *ps, char *state)
 
 	if (*state == 'Z')
 	{
-		ps->procstat_data.num_lwp  = 0;
-		ps->procstat_data.num_proc = 0;
+		ps->data.num_lwp  = 0;
+		ps->data.num_proc = 0;
 	}
 	else
 	{
-		ps->procstat_data.num_lwp = strtoul (fields[17], /* endptr = */ NULL, /* base = */ 10);
+		ps->data.num_lwp = strtoul (fields[17], /* endptr = */ NULL, /* base = */ 10);
 		if ((ps_read_status(pid, ps)) == NULL)
 		{
 			/* No VMem data */
-			ps->procstat_data.vmem_data = -1;
-			ps->procstat_data.vmem_code = -1;
+			ps->data.vmem_data = -1;
+			ps->data.vmem_code = -1;
 			DEBUG("ps_read_process: did not get vmem data for pid %li", pid);
 		}
-		if (ps->procstat_data.num_lwp == 0)
-			ps->procstat_data.num_lwp = 1;
-		ps->procstat_data.num_proc = 1;
+		if (ps->data.num_lwp == 0)
+			ps->data.num_lwp = 1;
+		ps->data.num_proc = 1;
 	}
 
 	/* Leave the rest at zero if this is only a zombi */
-	if (ps->procstat_data.num_proc == 0)
+	if (ps->data.num_proc == 0)
 	{
 		DEBUG ("processes plugin: This is only a zombie: pid = %li; "
 				"name = %s;", pid, ps->name);
@@ -1292,8 +1292,8 @@ static int ps_read_process (long pid, procstat_t *ps, char *state)
 	cpu_system_counter = atoll (fields[12]);
 	vmem_size          = atoll (fields[20]);
 	vmem_rss           = atoll (fields[21]);
-	ps->procstat_data.vmem_minflt_counter = atol (fields[7]);
-	ps->procstat_data.vmem_majflt_counter = atol (fields[9]);
+	ps->data.vmem_minflt_counter = atol (fields[7]);
+	ps->data.vmem_majflt_counter = atol (fields[9]);
 
 	{
 		unsigned long long stack_start = atoll (fields[25]);
@@ -1309,21 +1309,21 @@ static int ps_read_process (long pid, procstat_t *ps, char *state)
 	cpu_system_counter = cpu_system_counter * 1000000 / CONFIG_HZ;
 	vmem_rss = vmem_rss * pagesize_g;
 
-	ps->procstat_data.cpu_user_counter = cpu_user_counter;
-	ps->procstat_data.cpu_system_counter = cpu_system_counter;
-	ps->procstat_data.vmem_size = (unsigned long) vmem_size;
-	ps->procstat_data.vmem_rss = (unsigned long) vmem_rss;
-	ps->procstat_data.stack_size = (unsigned long) stack_size;
+	ps->data.cpu_user_counter = cpu_user_counter;
+	ps->data.cpu_system_counter = cpu_system_counter;
+	ps->data.vmem_size = (unsigned long) vmem_size;
+	ps->data.vmem_rss = (unsigned long) vmem_rss;
+	ps->data.stack_size = (unsigned long) stack_size;
 
 	if ( (ps_read_io (pid, ps)) == NULL)
 	{
 		/* no io data */
-		ps->procstat_data.io_rchar = -1;
-		ps->procstat_data.io_wchar = -1;
-		ps->procstat_data.io_syscr = -1;
-		ps->procstat_data.io_syscw = -1;
-		ps->procstat_data.io_diskr = -1;
-		ps->procstat_data.io_diskw = -1;
+		ps->data.io_rchar = -1;
+		ps->data.io_wchar = -1;
+		ps->data.io_syscr = -1;
+		ps->data.io_syscw = -1;
+		ps->data.io_diskr = -1;
+		ps->data.io_diskw = -1;
 
 		DEBUG("ps_read_process: not get io data for pid %li", pid);
 	}
@@ -1332,8 +1332,8 @@ static int ps_read_process (long pid, procstat_t *ps, char *state)
 	{
 		if ( (ps_read_tasks_status(pid, ps)) == NULL)
 		{
-			ps->procstat_data.cswitch_vol = -1;
-			ps->procstat_data.cswitch_invol = -1;
+			ps->data.cswitch_vol = -1;
+			ps->data.cswitch_invol = -1;
 
 			DEBUG("ps_read_tasks_status: not get context "
 					"switch data for pid %li", pid);
@@ -2089,33 +2089,33 @@ static int ps_read (void)
 		pse.id       = pid;
 		pse.age      = 0;
 
-		pse.procstat_data.num_proc   = ps.procstat_data.num_proc;
-		pse.procstat_data.num_lwp    = ps.procstat_data.num_lwp;
-		pse.procstat_data.vmem_size  = ps.procstat_data.vmem_size;
-		pse.procstat_data.vmem_rss   = ps.procstat_data.vmem_rss;
-		pse.procstat_data.vmem_data  = ps.procstat_data.vmem_data;
-		pse.procstat_data.vmem_code  = ps.procstat_data.vmem_code;
-		pse.procstat_data.stack_size = ps.procstat_data.stack_size;
+		pse.data.num_proc   = ps.data.num_proc;
+		pse.data.num_lwp    = ps.data.num_lwp;
+		pse.data.vmem_size  = ps.data.vmem_size;
+		pse.data.vmem_rss   = ps.data.vmem_rss;
+		pse.data.vmem_data  = ps.data.vmem_data;
+		pse.data.vmem_code  = ps.data.vmem_code;
+		pse.data.stack_size = ps.data.stack_size;
 
 		pse.vmem_minflt = 0;
-		pse.procstat_data.vmem_minflt_counter = ps.procstat_data.vmem_minflt_counter;
+		pse.data.vmem_minflt_counter = ps.data.vmem_minflt_counter;
 		pse.vmem_majflt = 0;
-		pse.procstat_data.vmem_majflt_counter = ps.procstat_data.vmem_majflt_counter;
+		pse.data.vmem_majflt_counter = ps.data.vmem_majflt_counter;
 
 		pse.cpu_user = 0;
-		pse.procstat_data.cpu_user_counter = ps.procstat_data.cpu_user_counter;
+		pse.data.cpu_user_counter = ps.data.cpu_user_counter;
 		pse.cpu_system = 0;
-		pse.procstat_data.cpu_system_counter = ps.procstat_data.cpu_system_counter;
+		pse.data.cpu_system_counter = ps.data.cpu_system_counter;
 
-		pse.procstat_data.io_rchar = ps.procstat_data.io_rchar;
-		pse.procstat_data.io_wchar = ps.procstat_data.io_wchar;
-		pse.procstat_data.io_syscr = ps.procstat_data.io_syscr;
-		pse.procstat_data.io_syscw = ps.procstat_data.io_syscw;
-		pse.procstat_data.io_diskr = ps.procstat_data.io_diskr;
-		pse.procstat_data.io_diskw = ps.procstat_data.io_diskw;
+		pse.data.io_rchar = ps.data.io_rchar;
+		pse.data.io_wchar = ps.data.io_wchar;
+		pse.data.io_syscr = ps.data.io_syscr;
+		pse.data.io_syscw = ps.data.io_syscw;
+		pse.data.io_diskr = ps.data.io_diskr;
+		pse.data.io_diskw = ps.data.io_diskw;
 
-		pse.procstat_data.cswitch_vol = ps.procstat_data.cswitch_vol;
-		pse.procstat_data.cswitch_invol = ps.procstat_data.cswitch_invol;
+		pse.data.cswitch_vol = ps.data.cswitch_vol;
+		pse.data.cswitch_invol = ps.data.cswitch_invol;
 
 		switch (state)
 		{

--- a/src/processes.c
+++ b/src/processes.c
@@ -2182,6 +2182,10 @@ static int ps_read (void)
 			pse.id       = procs[i].ki_pid;
 			pse.age      = 0;
 
+			/* no I/O data */
+			/* context switch counters not implemented */
+			pse.gauges = procstat_gauges_init;
+
 			pse.gauges.num_proc = 1;
 			pse.gauges.num_lwp  = procs[i].ki_numthreads;
 
@@ -2208,18 +2212,6 @@ static int ps_read (void)
 				pse.counters.cpu_system = procs[i].ki_rusage.ru_stime.tv_usec
 					+ (1000000lu * procs[i].ki_rusage.ru_stime.tv_sec);
 			}
-
-			/* no I/O data */
-			pse.gauges.io_rchar = -1;
-			pse.gauges.io_wchar = -1;
-			pse.gauges.io_syscr = -1;
-			pse.gauges.io_syscw = -1;
-			pse.gauges.io_diskr = -1;
-			pse.gauges.io_diskw = -1;
-
-			/* context switch counters not implemented */
-			pse.gauges.cswitch_vol   = -1;
-			pse.gauges.cswitch_invol = -1;
 
 			ps_list_add (procs[i].ki_comm, have_cmdline ? cmdline : NULL, &pse);
 
@@ -2326,6 +2318,10 @@ static int ps_read (void)
 			pse.id       = procs[i].p_pid;
 			pse.age      = 0;
 
+			/* no I/O data */
+			/* context switch counters not implemented */
+			pse.gauges = procstat_gauges_init;
+
 			pse.gauges.num_proc = 1;
 			pse.gauges.num_lwp  = 1; /* XXX: accumulate p_tid values for a single p_pid ? */
 
@@ -2341,18 +2337,6 @@ static int ps_read (void)
 						(1000000lu * procs[i].p_uutime_sec);
 			pse.counters.cpu_system = procs[i].p_ustime_usec +
 						(1000000lu * procs[i].p_ustime_sec);
-
-			/* no I/O data */
-			pse.gauges.io_rchar = -1;
-			pse.gauges.io_wchar = -1;
-			pse.gauges.io_syscr = -1;
-			pse.gauges.io_syscw = -1;
-			pse.gauges.io_diskr = -1;
-			pse.gauges.io_diskw = -1;
-
-			/* context switch counters not implemented */
-			pse.gauges.cswitch_vol   = -1;
-			pse.gauges.cswitch_invol = -1;
 
 			ps_list_add (procs[i].p_comm, have_cmdline ? cmdline : NULL, &pse);
 
@@ -2443,6 +2427,12 @@ static int ps_read (void)
 
 			pse.id       = procentry[i].pi_pid;
 			pse.age      = 0;
+
+			/* vmem_data, vmem_code, and stack_size not supported */
+			/* no I/O data */
+			/* context switch counters not implemented */
+			pse.gauges = procstat_gauges_init;
+
 			pse.gauges.num_lwp  = procentry[i].pi_thcount;
 			pse.gauges.num_proc = 1;
 
@@ -2483,20 +2473,6 @@ static int ps_read (void)
 
 			pse.gauges.vmem_size = procentry[i].pi_tsize + procentry[i].pi_dvm * pagesize;
 			pse.gauges.vmem_rss = (procentry[i].pi_drss + procentry[i].pi_trss) * pagesize;
-			/* Not supported */
-			pse.gauges.vmem_data = 0;
-			pse.gauges.vmem_code = 0;
-			pse.gauges.stack_size =  0;
-
-			pse.gauges.io_rchar = -1;
-			pse.gauges.io_wchar = -1;
-			pse.gauges.io_syscr = -1;
-			pse.gauges.io_syscw = -1;
-			pse.gauges.io_diskr = -1;
-			pse.gauges.io_diskw = -1;
-
-			pse.gauges.cswitch_vol   = -1;
-			pse.gauges.cswitch_invol = -1;
 
 			ps_list_add (cmdline, cargs, &pse);
 		} /* for (i = 0 .. nprocs) */

--- a/src/processes.c
+++ b/src/processes.c
@@ -180,7 +180,6 @@ typedef struct procstat_gauges_s {
 	derive_t cswitch_invol;
 } procstat_gauges_t;
 
-
 static procstat_gauges_t procstat_gauges_init = {
 	.num_proc      = 0,
 	.num_lwp       = 0,

--- a/src/processes.c
+++ b/src/processes.c
@@ -282,6 +282,10 @@ int     getthrds64( pid_t, void *, int, tid64_t *, int );
 int getargs (void *processBuffer, int bufferLen, char *argsBuffer, int argsLen);
 #endif /* HAVE_PROCINFO_H */
 
+static derive_t ps_delta(derive_t value) {
+	return (value == -1) ? 0 : value;
+}
+
 static void ps_procstat_gauges_add (procstat_gauges_t *dst, procstat_gauges_t *src) {
 	dst->num_proc   += src->num_proc;
 	dst->num_lwp    += src->num_lwp;
@@ -291,12 +295,12 @@ static void ps_procstat_gauges_add (procstat_gauges_t *dst, procstat_gauges_t *s
 	dst->vmem_code  += src->vmem_code;
 	dst->stack_size += src->stack_size;
 
-	dst->io_rchar   += ((src->io_rchar == -1)?0:src->io_rchar);
-	dst->io_wchar   += ((src->io_wchar == -1)?0:src->io_wchar);
-	dst->io_syscr   += ((src->io_syscr == -1)?0:src->io_syscr);
-	dst->io_syscw   += ((src->io_syscw == -1)?0:src->io_syscw);
-	dst->io_diskr   += ((src->io_diskr == -1)?0:src->io_diskr);
-	dst->io_diskw   += ((src->io_diskw == -1)?0:src->io_diskw);
+	dst->io_rchar   += ps_delta(src->io_rchar);
+	dst->io_wchar   += ps_delta(src->io_wchar);
+	dst->io_syscr   += ps_delta(src->io_syscr);
+	dst->io_syscw   += ps_delta(src->io_syscw);
+	dst->io_diskr   += ps_delta(src->io_diskr);
+	dst->io_diskw   += ps_delta(src->io_diskw);
 
 	dst->cswitch_vol   += ((src->cswitch_vol == -1)?0:src->cswitch_vol);
 	dst->cswitch_invol += ((src->cswitch_invol == -1)?0:src->cswitch_invol);

--- a/src/processes.c
+++ b/src/processes.c
@@ -266,6 +266,31 @@ int     getthrds64( pid_t, void *, int, tid64_t *, int );
 int getargs (void *processBuffer, int bufferLen, char *argsBuffer, int argsLen);
 #endif /* HAVE_PROCINFO_H */
 
+static void ps_copy_procstat_data (procstat_data_t *dst, procstat_data_t *src)
+{
+	if (src == NULL || dst == NULL) {
+		return;
+	}
+
+	dst->num_proc   = src->num_proc;
+	dst->num_lwp    = src->num_lwp;
+	dst->vmem_size  = src->vmem_size;
+	dst->vmem_rss   = src->vmem_rss;
+	dst->vmem_data  = src->vmem_data;
+	dst->vmem_code  = src->vmem_code;
+	dst->stack_size = src->stack_size;
+	
+	dst->io_rchar = src->io_rchar;
+	dst->io_wchar = src->io_wchar;
+	dst->io_syscr = src->io_syscr;
+	dst->io_syscw = src->io_syscw;
+	dst->io_diskr = src->io_diskr;
+	dst->io_diskw = src->io_diskw;
+
+	dst->cswitch_vol = src->cswitch_vol;
+	dst->cswitch_invol = src->cswitch_invol;
+}
+
 /* put name of process from config to list_head_g tree
  * list_head_g is a list of 'procstat_t' structs with
  * processes names we want to watch */
@@ -431,21 +456,8 @@ static void ps_list_add (const char *name, const char *cmdline, procstat_entry_t
 		}
 
 		pse->age = 0;
-		pse->data.num_proc   = entry->data.num_proc;
-		pse->data.num_lwp    = entry->data.num_lwp;
-		pse->data.vmem_size  = entry->data.vmem_size;
-		pse->data.vmem_rss   = entry->data.vmem_rss;
-		pse->data.vmem_data  = entry->data.vmem_data;
-		pse->data.vmem_code  = entry->data.vmem_code;
-		pse->data.stack_size = entry->data.stack_size;
-		pse->data.io_rchar   = entry->data.io_rchar;
-		pse->data.io_wchar   = entry->data.io_wchar;
-		pse->data.io_syscr   = entry->data.io_syscr;
-		pse->data.io_syscw   = entry->data.io_syscw;
-		pse->data.io_diskr   = entry->data.io_diskr;
-		pse->data.io_diskw   = entry->data.io_diskw;
-		pse->data.cswitch_vol   = entry->data.cswitch_vol;
-		pse->data.cswitch_invol = entry->data.cswitch_invol;
+
+		ps_copy_procstat_data(&pse->data, &entry->data);
 
 		ps->data.num_proc   += pse->data.num_proc;
 		ps->data.num_lwp    += pse->data.num_lwp;
@@ -2089,13 +2101,7 @@ static int ps_read (void)
 		pse.id       = pid;
 		pse.age      = 0;
 
-		pse.data.num_proc   = ps.data.num_proc;
-		pse.data.num_lwp    = ps.data.num_lwp;
-		pse.data.vmem_size  = ps.data.vmem_size;
-		pse.data.vmem_rss   = ps.data.vmem_rss;
-		pse.data.vmem_data  = ps.data.vmem_data;
-		pse.data.vmem_code  = ps.data.vmem_code;
-		pse.data.stack_size = ps.data.stack_size;
+		ps_copy_procstat_data(&pse.data, &ps.data);
 
 		pse.vmem_minflt = 0;
 		pse.data.vmem_minflt_counter = ps.data.vmem_minflt_counter;
@@ -2106,16 +2112,6 @@ static int ps_read (void)
 		pse.data.cpu_user_counter = ps.data.cpu_user_counter;
 		pse.cpu_system = 0;
 		pse.data.cpu_system_counter = ps.data.cpu_system_counter;
-
-		pse.data.io_rchar = ps.data.io_rchar;
-		pse.data.io_wchar = ps.data.io_wchar;
-		pse.data.io_syscr = ps.data.io_syscr;
-		pse.data.io_syscw = ps.data.io_syscw;
-		pse.data.io_diskr = ps.data.io_diskr;
-		pse.data.io_diskw = ps.data.io_diskw;
-
-		pse.data.cswitch_vol = ps.data.cswitch_vol;
-		pse.data.cswitch_invol = ps.data.cswitch_invol;
 
 		switch (state)
 		{

--- a/src/processes.c
+++ b/src/processes.c
@@ -159,51 +159,7 @@
 # endif
 #endif
 
-typedef struct procstat_entry_s
-{
-	unsigned long id;
-	unsigned long age;
-
-	unsigned long num_proc;
-	unsigned long num_lwp;
-	unsigned long vmem_size;
-	unsigned long vmem_rss;
-	unsigned long vmem_data;
-	unsigned long vmem_code;
-	unsigned long stack_size;
-
-	unsigned long vmem_minflt;
-	unsigned long vmem_majflt;
-	derive_t      vmem_minflt_counter;
-	derive_t      vmem_majflt_counter;
-
-	unsigned long cpu_user;
-	unsigned long cpu_system;
-	derive_t      cpu_user_counter;
-	derive_t      cpu_system_counter;
-
-	/* io data */
-	derive_t io_rchar;
-	derive_t io_wchar;
-	derive_t io_syscr;
-	derive_t io_syscw;
-	derive_t io_diskr;
-	derive_t io_diskw;
-
-	derive_t cswitch_vol;
-	derive_t cswitch_invol;
-
-	struct procstat_entry_s *next;
-} procstat_entry_t;
-
-#define PROCSTAT_NAME_LEN 256
-typedef struct procstat
-{
-	char          name[PROCSTAT_NAME_LEN];
-#if HAVE_REGEX_H
-	regex_t *re;
-#endif
-
+typedef struct {
 	unsigned long num_proc;
 	unsigned long num_lwp;
 	unsigned long vmem_size;
@@ -228,6 +184,33 @@ typedef struct procstat
 
 	derive_t cswitch_vol;
 	derive_t cswitch_invol;
+} procstat_data_t;
+
+typedef struct procstat_entry_s
+{
+	unsigned long id;
+	unsigned long age;
+
+	unsigned long vmem_minflt;
+	unsigned long vmem_majflt;
+
+	unsigned long cpu_user;
+	unsigned long cpu_system;
+
+	procstat_data_t procstat_data;
+
+	struct procstat_entry_s *next;
+} procstat_entry_t;
+
+#define PROCSTAT_NAME_LEN 256
+typedef struct procstat
+{
+	char          name[PROCSTAT_NAME_LEN];
+#if HAVE_REGEX_H
+	regex_t *re;
+#endif
+
+	procstat_data_t procstat_data;
 
 	struct procstat   *next;
 	struct procstat_entry_s *instances;
@@ -448,60 +431,60 @@ static void ps_list_add (const char *name, const char *cmdline, procstat_entry_t
 		}
 
 		pse->age = 0;
-		pse->num_proc   = entry->num_proc;
-		pse->num_lwp    = entry->num_lwp;
-		pse->vmem_size  = entry->vmem_size;
-		pse->vmem_rss   = entry->vmem_rss;
-		pse->vmem_data  = entry->vmem_data;
-		pse->vmem_code  = entry->vmem_code;
-		pse->stack_size = entry->stack_size;
-		pse->io_rchar   = entry->io_rchar;
-		pse->io_wchar   = entry->io_wchar;
-		pse->io_syscr   = entry->io_syscr;
-		pse->io_syscw   = entry->io_syscw;
-		pse->io_diskr   = entry->io_diskr;
-		pse->io_diskw   = entry->io_diskw;
-		pse->cswitch_vol   = entry->cswitch_vol;
-		pse->cswitch_invol = entry->cswitch_invol;
+		pse->procstat_data.num_proc   = entry->procstat_data.num_proc;
+		pse->procstat_data.num_lwp    = entry->procstat_data.num_lwp;
+		pse->procstat_data.vmem_size  = entry->procstat_data.vmem_size;
+		pse->procstat_data.vmem_rss   = entry->procstat_data.vmem_rss;
+		pse->procstat_data.vmem_data  = entry->procstat_data.vmem_data;
+		pse->procstat_data.vmem_code  = entry->procstat_data.vmem_code;
+		pse->procstat_data.stack_size = entry->procstat_data.stack_size;
+		pse->procstat_data.io_rchar   = entry->procstat_data.io_rchar;
+		pse->procstat_data.io_wchar   = entry->procstat_data.io_wchar;
+		pse->procstat_data.io_syscr   = entry->procstat_data.io_syscr;
+		pse->procstat_data.io_syscw   = entry->procstat_data.io_syscw;
+		pse->procstat_data.io_diskr   = entry->procstat_data.io_diskr;
+		pse->procstat_data.io_diskw   = entry->procstat_data.io_diskw;
+		pse->procstat_data.cswitch_vol   = entry->procstat_data.cswitch_vol;
+		pse->procstat_data.cswitch_invol = entry->procstat_data.cswitch_invol;
 
-		ps->num_proc   += pse->num_proc;
-		ps->num_lwp    += pse->num_lwp;
-		ps->vmem_size  += pse->vmem_size;
-		ps->vmem_rss   += pse->vmem_rss;
-		ps->vmem_data  += pse->vmem_data;
-		ps->vmem_code  += pse->vmem_code;
-		ps->stack_size += pse->stack_size;
+		ps->procstat_data.num_proc   += pse->procstat_data.num_proc;
+		ps->procstat_data.num_lwp    += pse->procstat_data.num_lwp;
+		ps->procstat_data.vmem_size  += pse->procstat_data.vmem_size;
+		ps->procstat_data.vmem_rss   += pse->procstat_data.vmem_rss;
+		ps->procstat_data.vmem_data  += pse->procstat_data.vmem_data;
+		ps->procstat_data.vmem_code  += pse->procstat_data.vmem_code;
+		ps->procstat_data.stack_size += pse->procstat_data.stack_size;
 
-		ps->io_rchar   += ((pse->io_rchar == -1)?0:pse->io_rchar);
-		ps->io_wchar   += ((pse->io_wchar == -1)?0:pse->io_wchar);
-		ps->io_syscr   += ((pse->io_syscr == -1)?0:pse->io_syscr);
-		ps->io_syscw   += ((pse->io_syscw == -1)?0:pse->io_syscw);
-		ps->io_diskr   += ((pse->io_diskr == -1)?0:pse->io_diskr);
-		ps->io_diskw   += ((pse->io_diskw == -1)?0:pse->io_diskw);
+		ps->procstat_data.io_rchar   += ((pse->procstat_data.io_rchar == -1)?0:pse->procstat_data.io_rchar);
+		ps->procstat_data.io_wchar   += ((pse->procstat_data.io_wchar == -1)?0:pse->procstat_data.io_wchar);
+		ps->procstat_data.io_syscr   += ((pse->procstat_data.io_syscr == -1)?0:pse->procstat_data.io_syscr);
+		ps->procstat_data.io_syscw   += ((pse->procstat_data.io_syscw == -1)?0:pse->procstat_data.io_syscw);
+		ps->procstat_data.io_diskr   += ((pse->procstat_data.io_diskr == -1)?0:pse->procstat_data.io_diskr);
+		ps->procstat_data.io_diskw   += ((pse->procstat_data.io_diskw == -1)?0:pse->procstat_data.io_diskw);
 
-		ps->cswitch_vol   += ((pse->cswitch_vol == -1)?0:pse->cswitch_vol);
-		ps->cswitch_invol += ((pse->cswitch_invol == -1)?0:pse->cswitch_invol);
-		want_init = (entry->vmem_minflt_counter == 0)
-				&& (entry->vmem_majflt_counter == 0);
+		ps->procstat_data.cswitch_vol   += ((pse->procstat_data.cswitch_vol == -1)?0:pse->procstat_data.cswitch_vol);
+		ps->procstat_data.cswitch_invol += ((pse->procstat_data.cswitch_invol == -1)?0:pse->procstat_data.cswitch_invol);
+		want_init = (entry->procstat_data.vmem_minflt_counter == 0)
+				&& (entry->procstat_data.vmem_majflt_counter == 0);
 		ps_update_counter (want_init,
-				&ps->vmem_minflt_counter,
-				&pse->vmem_minflt_counter, &pse->vmem_minflt,
-				entry->vmem_minflt_counter, entry->vmem_minflt);
+				&ps->procstat_data.vmem_minflt_counter,
+				&pse->procstat_data.vmem_minflt_counter, &pse->vmem_minflt,
+				entry->procstat_data.vmem_minflt_counter, entry->vmem_minflt);
 		ps_update_counter (want_init,
-				&ps->vmem_majflt_counter,
-				&pse->vmem_majflt_counter, &pse->vmem_majflt,
-				entry->vmem_majflt_counter, entry->vmem_majflt);
+				&ps->procstat_data.vmem_majflt_counter,
+				&pse->procstat_data.vmem_majflt_counter, &pse->vmem_majflt,
+				entry->procstat_data.vmem_majflt_counter, entry->vmem_majflt);
 
-		want_init = (entry->cpu_user_counter == 0)
-				&& (entry->cpu_system_counter == 0);
+		want_init = (entry->procstat_data.cpu_user_counter == 0)
+				&& (entry->procstat_data.cpu_system_counter == 0);
 		ps_update_counter (want_init,
-				&ps->cpu_user_counter,
-				&pse->cpu_user_counter, &pse->cpu_user,
-				entry->cpu_user_counter, entry->cpu_user);
+				&ps->procstat_data.cpu_user_counter,
+				&pse->procstat_data.cpu_user_counter, &pse->cpu_user,
+				entry->procstat_data.cpu_user_counter, entry->cpu_user);
 		ps_update_counter (want_init,
-				&ps->cpu_system_counter,
-				&pse->cpu_system_counter, &pse->cpu_system,
-				entry->cpu_system_counter, entry->cpu_system);
+				&ps->procstat_data.cpu_system_counter,
+				&pse->procstat_data.cpu_system_counter, &pse->cpu_system,
+				entry->procstat_data.cpu_system_counter, entry->cpu_system);
 	}
 }
 
@@ -513,21 +496,21 @@ static void ps_list_reset (void)
 
 	for (procstat_t *ps = list_head_g; ps != NULL; ps = ps->next)
 	{
-		ps->num_proc    = 0;
-		ps->num_lwp     = 0;
-		ps->vmem_size   = 0;
-		ps->vmem_rss    = 0;
-		ps->vmem_data   = 0;
-		ps->vmem_code   = 0;
-		ps->stack_size  = 0;
-		ps->io_rchar = -1;
-		ps->io_wchar = -1;
-		ps->io_syscr = -1;
-		ps->io_syscw = -1;
-		ps->io_diskr = -1;
-		ps->io_diskw = -1;
-		ps->cswitch_vol   = -1;
-		ps->cswitch_invol = -1;
+		ps->procstat_data.num_proc    = 0;
+		ps->procstat_data.num_lwp     = 0;
+		ps->procstat_data.vmem_size   = 0;
+		ps->procstat_data.vmem_rss    = 0;
+		ps->procstat_data.vmem_data   = 0;
+		ps->procstat_data.vmem_code   = 0;
+		ps->procstat_data.stack_size  = 0;
+		ps->procstat_data.io_rchar = -1;
+		ps->procstat_data.io_wchar = -1;
+		ps->procstat_data.io_syscr = -1;
+		ps->procstat_data.io_syscw = -1;
+		ps->procstat_data.io_diskr = -1;
+		ps->procstat_data.io_diskw = -1;
+		ps->procstat_data.cswitch_vol   = -1;
+		ps->procstat_data.cswitch_invol = -1;
 
 		pse_prev = NULL;
 		pse = ps->instances;
@@ -796,25 +779,7 @@ static void ps_submit_proc_stats (
         const char *owner,
         const char *command,
         const char *command_line,
-        unsigned long num_proc,
-        unsigned long num_lwp,
-        unsigned long vmem_size,
-        unsigned long vmem_rss,
-        unsigned long vmem_data,
-        unsigned long vmem_code,
-        unsigned long stack_size,
-        derive_t vmem_minflt_counter,
-        derive_t vmem_majflt_counter,
-        derive_t cpu_user_counter,
-        derive_t cpu_system_counter,
-        derive_t io_rchar,
-        derive_t io_wchar,
-        derive_t io_syscr,
-        derive_t io_syscw,
-        derive_t io_diskr,
-        derive_t io_diskw,
-	derive_t cswitch_vol,
-        derive_t cswitch_invol)
+        procstat_data_t procstat_data)
 {
     const want_detail_configuration_t *config = &want_detail_configuration_g;
     value_t values[MAX_VALUE_LIST_SIZE];
@@ -844,73 +809,73 @@ static void ps_submit_proc_stats (
         }
     }
 
-    vl.values[0].gauge = num_proc;
-    vl.values[1].gauge = num_lwp;
+    vl.values[0].gauge = procstat_data.num_proc;
+    vl.values[1].gauge = procstat_data.num_lwp;
     dispatch_value_helper(&vl, "ps_count", NULL, 2, doing_detail, config->ps_count);
 
-    vl.values[0].gauge = vmem_size;
+    vl.values[0].gauge = procstat_data.vmem_size;
     dispatch_value_helper(&vl, "ps_vm", NULL, 1, doing_detail, config->ps_vm);
 
-    vl.values[0].gauge = vmem_rss;
+    vl.values[0].gauge = procstat_data.vmem_rss;
     dispatch_value_helper(&vl, "ps_rss", NULL, 1, doing_detail, config->ps_rss);
 
-    vl.values[0].gauge = vmem_data;
+    vl.values[0].gauge = procstat_data.vmem_data;
     dispatch_value_helper(&vl, "ps_data", NULL, 1, doing_detail, config->ps_data);
 
-    vl.values[0].gauge = vmem_code;
+    vl.values[0].gauge = procstat_data.vmem_code;
     dispatch_value_helper(&vl, "ps_code", NULL, 1, doing_detail, config->ps_code);
 
-    vl.values[0].gauge = stack_size;
+    vl.values[0].gauge = procstat_data.stack_size;
     dispatch_value_helper(&vl, "ps_stacksize", NULL, 1, doing_detail,
                           config->ps_stacksize);
 
-    vl.values[0].derive = vmem_minflt_counter;
-    vl.values[1].derive = vmem_majflt_counter;
+    vl.values[0].derive = procstat_data.vmem_minflt_counter;
+    vl.values[1].derive = procstat_data.vmem_majflt_counter;
     dispatch_value_helper(&vl, "ps_pagefaults", NULL, 2, doing_detail,
                           config->ps_pagefaults);
 
-    vl.values[0].derive = cpu_user_counter;
-    vl.values[1].derive = cpu_system_counter;
+    vl.values[0].derive = procstat_data.cpu_user_counter;
+    vl.values[1].derive = procstat_data.cpu_system_counter;
     dispatch_value_helper(&vl, "ps_cputime", NULL, 2, doing_detail,
                           config->ps_cputime);
 
-    if ( (io_rchar != -1) && (io_wchar != -1) )
+    if ( (procstat_data.io_rchar != -1) && (procstat_data.io_wchar != -1) )
     {
-        vl.values[0].derive = io_rchar;
-        vl.values[1].derive = io_wchar;
+        vl.values[0].derive = procstat_data.io_rchar;
+        vl.values[1].derive = procstat_data.io_wchar;
         dispatch_value_helper(&vl, "io_octets", NULL, 2, doing_detail,
                 config->ps_disk_octets);
     }
 
-    if ( (io_syscr != -1) && (io_syscw != -1) )
+    if ( (procstat_data.io_syscr != -1) && (procstat_data.io_syscw != -1) )
     {
-        vl.values[0].derive = io_syscr;
-        vl.values[1].derive = io_syscw;
+        vl.values[0].derive = procstat_data.io_syscr;
+        vl.values[1].derive = procstat_data.io_syscw;
         dispatch_value_helper(&vl, "io_ops", NULL, 2, doing_detail,
                               config->ps_disk_ops);
     }
 
-    if ( (io_diskr != -1) && (io_diskw != -1) )
+    if ( (procstat_data.io_diskr != -1) && (procstat_data.io_diskw != -1) )
     {
-        vl.values[0].derive = io_diskr;
-        vl.values[1].derive = io_diskw;
+        vl.values[0].derive = procstat_data.io_diskr;
+        vl.values[1].derive = procstat_data.io_diskw;
         dispatch_value_helper(&vl, "disk_octets", NULL, 2, doing_detail,
                               config->ps_disk_octets);
     }
 
     if ( report_ctx_switch )
     {
-	    vl.values[0].derive = cswitch_vol;
+	    vl.values[0].derive = procstat_data.cswitch_vol;
 	    dispatch_value_helper(&vl, "contextswitch", "voluntary", 2, doing_detail,
 		    config->cswitch_vol);
-	    vl.values[0].derive = cswitch_invol;
+	    vl.values[0].derive = procstat_data.cswitch_invol;
 	    dispatch_value_helper(&vl, "contextswitch", "involuntary", 2, doing_detail,
 		    config->cswitch_invol);
     }
     meta_data_destroy(vl.meta);
     vl.meta = NULL;
 
-    DEBUG ("name = %s; num_proc = %lu; num_lwp = %lu; "
+    DEBUG ("name = %s; pid = %s; num_proc = %lu; num_lwp = %lu; "
             "vmem_size = %lu; vmem_rss = %lu; vmem_data = %lu; "
             "vmem_code = %lu; "
             "vmem_minflt_counter = %"PRIi64"; vmem_majflt_counter = %"PRIi64"; "
@@ -919,14 +884,14 @@ static void ps_submit_proc_stats (
             "io_syscr = %"PRIi64"; io_syscw = %"PRIi64";"
             "io_diskr = %"PRIi64"; io_diskw = %"PRIi64";"
             "cswitch_vol = %"PRIi64"; cswitch_invol = %"PRIi64";",
-            instance_name, num_proc, num_lwp,
-            vmem_size, vmem_rss,
-            vmem_data, vmem_code,
-            vmem_minflt_counter, vmem_majflt_counter,
-            cpu_user_counter, cpu_system_counter,
-            io_rchar, io_wchar, io_syscr, io_syscw,
-            io_diskr, io_diskw,
-            cswitch_vol, cswitch_invol);
+            instance_name, pid, procstat_data.num_proc, procstat_data.num_lwp,
+            procstat_data.vmem_size, procstat_data.vmem_rss,
+            procstat_data.vmem_data, procstat_data.vmem_code,
+            procstat_data.vmem_minflt_counter, procstat_data.vmem_majflt_counter,
+            procstat_data.cpu_user_counter, procstat_data.cpu_system_counter,
+            procstat_data.io_rchar, procstat_data.io_wchar, procstat_data.io_syscr, procstat_data.io_syscw,
+            procstat_data.io_diskr, procstat_data.io_diskw,
+            procstat_data.cswitch_vol, procstat_data.cswitch_invol);
 } /* void ps_submit_proc_list */
 
 #undef MAX_VALUE_LIST_SIZE
@@ -958,25 +923,7 @@ static void ps_submit_procstat_entry (const char *instance_name,
             owner,
             command,
             cmd_line_to_use,
-            entry->num_proc,
-            entry->num_lwp,
-            entry->vmem_size,
-            entry->vmem_rss,
-            entry->vmem_data,
-            entry->vmem_code,
-            entry->stack_size,
-            entry->cpu_user_counter,
-            entry->cpu_system_counter,
-            entry->vmem_minflt_counter,
-            entry->vmem_majflt_counter,
-            entry->io_rchar,
-            entry->io_wchar,
-            entry->io_syscr,
-            entry->io_syscw,
-            entry->io_diskr,
-            entry->io_diskw,
-	    entry->cswitch_vol,
-	    entry->cswitch_invol);
+            entry->procstat_data);
 
     sfree (command);
     sfree (owner);
@@ -991,25 +938,7 @@ static void ps_submit_proc_list (procstat_t *ps)
             NULL,  // owner
             NULL,  // command
             NULL,  // command_line
-            ps->num_proc,
-            ps->num_lwp,
-            ps->vmem_size,
-            ps->vmem_rss,
-            ps->vmem_data,
-            ps->vmem_code,
-            ps->stack_size,
-            ps->cpu_user_counter,
-            ps->cpu_system_counter,
-            ps->vmem_minflt_counter,
-            ps->vmem_majflt_counter,
-            ps->io_rchar,
-            ps->io_wchar,
-            ps->io_syscr,
-            ps->io_syscw,
-            ps->io_diskr,
-            ps->io_diskw,
-	    ps->cswitch_vol,
-	    ps->cswitch_invol);
+            ps->procstat_data);
 
     if (some_detail_active_g) {
         procstat_entry_t *entry;
@@ -1119,8 +1048,8 @@ static procstat_t *ps_read_tasks_status (long pid, procstat_t *ps)
 	}
 	closedir (dh);
 
-	ps->cswitch_vol = cswitch_vol;
-	ps->cswitch_invol = cswitch_invol;
+	ps->procstat_data.cswitch_vol = cswitch_vol;
+	ps->procstat_data.cswitch_invol = cswitch_invol;
 
 	return (ps);
 } /* int *ps_read_tasks_status */
@@ -1188,10 +1117,10 @@ static procstat_t *ps_read_status (long pid, procstat_t *ps)
 				sstrerror (errno, errbuf, sizeof (errbuf)));
 	}
 
-	ps->vmem_data = data * 1024;
-	ps->vmem_code = (exe + lib) * 1024;
+	ps->procstat_data.vmem_data = data * 1024;
+	ps->procstat_data.vmem_code = (exe + lib) * 1024;
 	if (threads != 0)
-		ps->num_lwp = threads;
+		ps->procstat_data.num_lwp = threads;
 
 	return (ps);
 } /* procstat_t *ps_read_vmem */
@@ -1216,17 +1145,17 @@ static procstat_t *ps_read_io (long pid, procstat_t *ps)
 		char *endptr;
 
 		if (strncasecmp (buffer, "rchar:", 6) == 0)
-			val = &(ps->io_rchar);
+			val = &(ps->procstat_data.io_rchar);
 		else if (strncasecmp (buffer, "wchar:", 6) == 0)
-			val = &(ps->io_wchar);
+			val = &(ps->procstat_data.io_wchar);
 		else if (strncasecmp (buffer, "syscr:", 6) == 0)
-			val = &(ps->io_syscr);
+			val = &(ps->procstat_data.io_syscr);
 		else if (strncasecmp (buffer, "syscw:", 6) == 0)
-			val = &(ps->io_syscw);
+			val = &(ps->procstat_data.io_syscw);
 		else if (strncasecmp (buffer, "read_bytes:", 11) == 0)
-			val = &(ps->io_diskr);
+			val = &(ps->procstat_data.io_diskr);
 		else if (strncasecmp (buffer, "write_bytes:", 12) == 0)
-			val = &(ps->io_diskw);
+			val = &(ps->procstat_data.io_diskw);
 		else
 			continue;
 
@@ -1333,26 +1262,26 @@ static int ps_read_process (long pid, procstat_t *ps, char *state)
 
 	if (*state == 'Z')
 	{
-		ps->num_lwp  = 0;
-		ps->num_proc = 0;
+		ps->procstat_data.num_lwp  = 0;
+		ps->procstat_data.num_proc = 0;
 	}
 	else
 	{
-		ps->num_lwp = strtoul (fields[17], /* endptr = */ NULL, /* base = */ 10);
+		ps->procstat_data.num_lwp = strtoul (fields[17], /* endptr = */ NULL, /* base = */ 10);
 		if ((ps_read_status(pid, ps)) == NULL)
 		{
 			/* No VMem data */
-			ps->vmem_data = -1;
-			ps->vmem_code = -1;
+			ps->procstat_data.vmem_data = -1;
+			ps->procstat_data.vmem_code = -1;
 			DEBUG("ps_read_process: did not get vmem data for pid %li", pid);
 		}
-		if (ps->num_lwp == 0)
-			ps->num_lwp = 1;
-		ps->num_proc = 1;
+		if (ps->procstat_data.num_lwp == 0)
+			ps->procstat_data.num_lwp = 1;
+		ps->procstat_data.num_proc = 1;
 	}
 
 	/* Leave the rest at zero if this is only a zombi */
-	if (ps->num_proc == 0)
+	if (ps->procstat_data.num_proc == 0)
 	{
 		DEBUG ("processes plugin: This is only a zombie: pid = %li; "
 				"name = %s;", pid, ps->name);
@@ -1363,8 +1292,8 @@ static int ps_read_process (long pid, procstat_t *ps, char *state)
 	cpu_system_counter = atoll (fields[12]);
 	vmem_size          = atoll (fields[20]);
 	vmem_rss           = atoll (fields[21]);
-	ps->vmem_minflt_counter = atol (fields[7]);
-	ps->vmem_majflt_counter = atol (fields[9]);
+	ps->procstat_data.vmem_minflt_counter = atol (fields[7]);
+	ps->procstat_data.vmem_majflt_counter = atol (fields[9]);
 
 	{
 		unsigned long long stack_start = atoll (fields[25]);
@@ -1380,21 +1309,21 @@ static int ps_read_process (long pid, procstat_t *ps, char *state)
 	cpu_system_counter = cpu_system_counter * 1000000 / CONFIG_HZ;
 	vmem_rss = vmem_rss * pagesize_g;
 
-	ps->cpu_user_counter = cpu_user_counter;
-	ps->cpu_system_counter = cpu_system_counter;
-	ps->vmem_size = (unsigned long) vmem_size;
-	ps->vmem_rss = (unsigned long) vmem_rss;
-	ps->stack_size = (unsigned long) stack_size;
+	ps->procstat_data.cpu_user_counter = cpu_user_counter;
+	ps->procstat_data.cpu_system_counter = cpu_system_counter;
+	ps->procstat_data.vmem_size = (unsigned long) vmem_size;
+	ps->procstat_data.vmem_rss = (unsigned long) vmem_rss;
+	ps->procstat_data.stack_size = (unsigned long) stack_size;
 
 	if ( (ps_read_io (pid, ps)) == NULL)
 	{
 		/* no io data */
-		ps->io_rchar = -1;
-		ps->io_wchar = -1;
-		ps->io_syscr = -1;
-		ps->io_syscw = -1;
-		ps->io_diskr = -1;
-		ps->io_diskw = -1;
+		ps->procstat_data.io_rchar = -1;
+		ps->procstat_data.io_wchar = -1;
+		ps->procstat_data.io_syscr = -1;
+		ps->procstat_data.io_syscw = -1;
+		ps->procstat_data.io_diskr = -1;
+		ps->procstat_data.io_diskw = -1;
 
 		DEBUG("ps_read_process: not get io data for pid %li", pid);
 	}
@@ -1403,8 +1332,8 @@ static int ps_read_process (long pid, procstat_t *ps, char *state)
 	{
 		if ( (ps_read_tasks_status(pid, ps)) == NULL)
 		{
-			ps->cswitch_vol = -1;
-			ps->cswitch_invol = -1;
+			ps->procstat_data.cswitch_vol = -1;
+			ps->procstat_data.cswitch_invol = -1;
 
 			DEBUG("ps_read_tasks_status: not get context "
 					"switch data for pid %li", pid);
@@ -2160,33 +2089,33 @@ static int ps_read (void)
 		pse.id       = pid;
 		pse.age      = 0;
 
-		pse.num_proc   = ps.num_proc;
-		pse.num_lwp    = ps.num_lwp;
-		pse.vmem_size  = ps.vmem_size;
-		pse.vmem_rss   = ps.vmem_rss;
-		pse.vmem_data  = ps.vmem_data;
-		pse.vmem_code  = ps.vmem_code;
-		pse.stack_size = ps.stack_size;
+		pse.procstat_data.num_proc   = ps.procstat_data.num_proc;
+		pse.procstat_data.num_lwp    = ps.procstat_data.num_lwp;
+		pse.procstat_data.vmem_size  = ps.procstat_data.vmem_size;
+		pse.procstat_data.vmem_rss   = ps.procstat_data.vmem_rss;
+		pse.procstat_data.vmem_data  = ps.procstat_data.vmem_data;
+		pse.procstat_data.vmem_code  = ps.procstat_data.vmem_code;
+		pse.procstat_data.stack_size = ps.procstat_data.stack_size;
 
 		pse.vmem_minflt = 0;
-		pse.vmem_minflt_counter = ps.vmem_minflt_counter;
+		pse.procstat_data.vmem_minflt_counter = ps.procstat_data.vmem_minflt_counter;
 		pse.vmem_majflt = 0;
-		pse.vmem_majflt_counter = ps.vmem_majflt_counter;
+		pse.procstat_data.vmem_majflt_counter = ps.procstat_data.vmem_majflt_counter;
 
 		pse.cpu_user = 0;
-		pse.cpu_user_counter = ps.cpu_user_counter;
+		pse.procstat_data.cpu_user_counter = ps.procstat_data.cpu_user_counter;
 		pse.cpu_system = 0;
-		pse.cpu_system_counter = ps.cpu_system_counter;
+		pse.procstat_data.cpu_system_counter = ps.procstat_data.cpu_system_counter;
 
-		pse.io_rchar = ps.io_rchar;
-		pse.io_wchar = ps.io_wchar;
-		pse.io_syscr = ps.io_syscr;
-		pse.io_syscw = ps.io_syscw;
-		pse.io_diskr = ps.io_diskr;
-		pse.io_diskw = ps.io_diskw;
+		pse.procstat_data.io_rchar = ps.procstat_data.io_rchar;
+		pse.procstat_data.io_wchar = ps.procstat_data.io_wchar;
+		pse.procstat_data.io_syscr = ps.procstat_data.io_syscr;
+		pse.procstat_data.io_syscw = ps.procstat_data.io_syscw;
+		pse.procstat_data.io_diskr = ps.procstat_data.io_diskr;
+		pse.procstat_data.io_diskw = ps.procstat_data.io_diskw;
 
-		pse.cswitch_vol = ps.cswitch_vol;
-		pse.cswitch_invol = ps.cswitch_invol;
+		pse.procstat_data.cswitch_vol = ps.procstat_data.cswitch_vol;
+		pse.procstat_data.cswitch_invol = ps.procstat_data.cswitch_invol;
 
 		switch (state)
 		{


### PR DESCRIPTION
I have a feeling we can go with something more concise for the field name in the struct such as "data", so that we can reduce the character count per line easier. Validating the general implementation, I will go back and rename if necessary.

Also logging the pid when debugging to help narrow down specific processes across log lines.