### PR TITLE
Converted read_agent_logging to a one-shot script

### DIFF
--- a/src/read_agent_logging.in
+++ b/src/read_agent_logging.in
@@ -3,9 +3,9 @@
 # text format. It currently only supports what's needed for the Stackdriver
 # Logging agent.
 #
-# This script handles the input line by line, and keeps running until EOF. This
-# is the recommended behavior for long-running collectd plugins, to reduce
-# start-up cost.
+# This script polls the metrics endpoint once and leaves. It used to run until
+# aborted, but in some cases something was preventing it from terminating when
+# collectd was restarted.
 #
 # Sample configuration stanza:
 # <Plugin "exec">
@@ -15,9 +15,6 @@
 
 # Read first arg, with a safe default for testing.
 URL="${1:-http://localhost:24231/metrics}"
-
-# Default to 10s if unset, as a fail-safe mechanism.
-INTERVAL=${COLLECTD_INTERVAL:-10}
 
 # 1. If the Logging Agent uses REST.
 # The part of the input that sed looks at looks like:
@@ -118,22 +115,20 @@ INTERVAL=${COLLECTD_INTERVAL:-10}
 #
 #   PUTVAL /agent-13/derive-log_entry_retry_count N:600
 #   PUTVAL /agent-14/derive-log_entry_retry_count N:290
-while :; do
-  # - Only pass to sed the Stackdriver metrics.
-  # - Combine successful and failed submetrics into one with response code (200
-  #   for successful), in order to fit the schema that Stackdriver expects.
-  # - Make all nouns singular.
-  # - Successful metrics don't have a response code in the input, so set it
-  #   here.
-  # - The first two lines handle ingested/dropped entries as a corner case until
-  #   the agent starts exporting the partial errors for dropped entries, then
-  #   the rest of the sed expression should handle them generically.
-  curl --silent "${URL}" \
-    | grep -E '^stackdriver_' \
-    | sed -E \
-      -e "s/^stackdriver_([a-zA-Z0-9_]*)(\{(.*code=\"([0-9]*)\")?.*\})? ([0-9]*)/PUTVAL ${COLLECTD_HOSTNAME}\/agent-\4\/derive-\1 N:\5/" \
-      -e "s/(successful|failed)_requests_count/request_count/" \
-      -e "s/(ingested|dropped)_entries_count/log_entry_count/" \
-      -e "s/retried_entries_count/log_entry_retry_count/"
-  sleep "${INTERVAL}"
-done
+
+# - Only pass to sed the Stackdriver metrics.
+# - Combine successful and failed submetrics into one with response code (200
+#   for successful), in order to fit the schema that Stackdriver expects.
+# - Make all nouns singular.
+# - Successful metrics don't have a response code in the input, so set it
+#   here.
+# - The first two lines handle ingested/dropped entries as a corner case until
+#   the agent starts exporting the partial errors for dropped entries, then
+#   the rest of the sed expression should handle them generically.
+curl --silent "${URL}" \
+  | grep -E '^stackdriver_' \
+  | sed -E \
+    -e "s/^stackdriver_([a-zA-Z0-9_]*)(\{(.*code=\"([0-9]*)\")?.*\})? ([0-9]*)/PUTVAL ${COLLECTD_HOSTNAME}\/agent-\4\/derive-\1 N:\5/" \
+    -e "s/(successful|failed)_requests_count/request_count/" \
+    -e "s/(ingested|dropped)_entries_count/log_entry_count/" \
+    -e "s/retried_entries_count/log_entry_retry_count/"

--- a/src/read_agent_logging.in
+++ b/src/read_agent_logging.in
@@ -125,7 +125,7 @@ URL="${1:-http://localhost:24231/metrics}"
 # - The first two lines handle ingested/dropped entries as a corner case until
 #   the agent starts exporting the partial errors for dropped entries, then
 #   the rest of the sed expression should handle them generically.
-curl --silent "${URL}" \
+exec curl --silent "${URL}" \
   | grep -E '^stackdriver_' \
   | sed -E \
     -e "s/^stackdriver_([a-zA-Z0-9_]*)(\{(.*code=\"([0-9]*)\")?.*\})? ([0-9]*)/PUTVAL ${COLLECTD_HOSTNAME}\/agent-\4\/derive-\1 N:\5/" \


### PR DESCRIPTION
It used to run until aborted, but in some cases something was preventing it from terminating when collectd was restarted, leaving multiple copies in the system.