### PR TITLE
Patch for mysql plugin memory leak

### DIFF
--- a/src/mysql.c
+++ b/src/mysql.c
@@ -291,15 +291,18 @@ static MYSQL *getconnection (mysql_database_t *db)
 	}
 	db->is_connected = 0;
 
+	/* Close the old connection before initializing a new one. */
+	if (db->con != NULL) {
+		mysql_close(db->con);
+		db->con = NULL;
+	}
+
+	db->con = mysql_init (NULL);
 	if (db->con == NULL)
 	{
-		db->con = mysql_init (NULL);
-		if (db->con == NULL)
-		{
-			ERROR ("mysql plugin: mysql_init failed: %s",
-					mysql_error (db->con));
-			return (NULL);
-		}
+		ERROR ("mysql plugin: mysql_init failed: %s",
+                                mysql_error (db->con));
+		return (NULL);
 	}
 
 	/* Configure TCP connect timeout (default: 0) */


### PR DESCRIPTION
Resolves memory leaked introduced in mysql library implementation which doesn't cleanup properly after repeated calls to `mysql_real_connect`. See https://github.com/collectd/collectd/pull/2704 for reference.