### PR TITLE
Update Write GCM plugin for compatibility with OpenSSL 1.1 API

### DIFF
--- a/src/write_gcm.c
+++ b/src/write_gcm.c
@@ -1135,28 +1135,45 @@ static int wg_oauth2_sign(unsigned char *signature, size_t sig_capacity,
     ERROR("write_gcm: signature buffer not big enough.");
     return -1;
   }
-  EVP_MD_CTX ctx;
-  EVP_SignInit(&ctx, EVP_sha256());
+  
+  #if OPENSSL_VERSION_NUMBER < 0x10100000L
+  EVP_MD_CTX md_ctx;
+  EVP_MD_CTX* ctx = &md_ctx; 
+  #else 
+  EVP_MD_CTX* ctx;
+  ctx = EVP_MD_CTX_new();
+  #endif
+
+  EVP_SignInit(ctx, EVP_sha256());
 
   char err_buf[1024];
-  if (EVP_SignUpdate(&ctx, buffer, size) == 0) {
+  if (EVP_SignUpdate(ctx, buffer, size) == 0) {
     ERR_error_string_n(ERR_get_error(), err_buf, sizeof(err_buf));
     ERROR("write_gcm: EVP_SignUpdate failed: %s", err_buf);
-    EVP_MD_CTX_cleanup(&ctx);
+    #if OPENSSL_VERSION_NUMBER < 0x10100000L
+    EVP_MD_CTX_cleanup(ctx);
+    #else 
+    EVP_MD_CTX_free(ctx);
+    #endif
     return -1;
   }
 
-  if (EVP_SignFinal(&ctx, signature, actual_sig_size, pkey) == 0) {
+  if (EVP_SignFinal(ctx, signature, actual_sig_size, pkey) == 0) {
     ERR_error_string_n(ERR_get_error(), err_buf, sizeof(err_buf));
     ERROR ("write_gcm: EVP_SignFinal failed: %s", err_buf);
-    EVP_MD_CTX_cleanup(&ctx);
+    #if OPENSSL_VERSION_NUMBER < 0x10100000L
+    EVP_MD_CTX_cleanup(ctx);
+    #else 
+    EVP_MD_CTX_free(ctx);
+    #endif
     return -1;
   }
-  if (EVP_MD_CTX_cleanup(&ctx) == 0) {
-    ERR_error_string_n(ERR_get_error(), err_buf, sizeof(err_buf));
-    ERROR ("write_gcm: EVP_MD_CTX_cleanup failed: %s", err_buf);
-    return -1;
-  }
+
+  #if OPENSSL_VERSION_NUMBER < 0x10100000L
+  EVP_MD_CTX_cleanup(ctx);
+  #else 
+  EVP_MD_CTX_free(ctx);
+  #endif
   return 0;
 }
 

--- a/src/write_gcm.c
+++ b/src/write_gcm.c
@@ -141,6 +141,14 @@ static _Bool wg_some_error_occurred_g = 0;
 #if OPENSSL_VERSION_NUMBER < 0x10100000L
 #include <openssl/engine.h>
 
+static void *OPENSSL_zalloc(size_t num) {
+  void *ret = OPENSSL_malloc(num);
+
+  if (ret != NULL)
+    memset(ret, 0, num);
+  return ret;
+}
+
 EVP_MD_CTX *EVP_MD_CTX_new(void) {
   return OPENSSL_zalloc(sizeof(EVP_MD_CTX));
 }

--- a/src/write_gcm.c
+++ b/src/write_gcm.c
@@ -1170,7 +1170,11 @@ static int wg_oauth2_sign(unsigned char *signature, size_t sig_capacity,
   }
 
   #if OPENSSL_VERSION_NUMBER < 0x10100000L
-  EVP_MD_CTX_cleanup(ctx);
+  if (EVP_MD_CTX_cleanup(ctx) == 0) {
+    ERR_error_string_n(ERR_get_error(), err_buf, sizeof(err_buf));
+    ERROR ("write_gcm: EVP_MD_CTX_cleanup failed: %s", err_buf);
+    return -1;
+  }
   #else 
   EVP_MD_CTX_free(ctx);
   #endif


### PR DESCRIPTION
While building for Ubuntu 18.04, I ran into issues building against libcurl4 and libssl1.1. 

I updated the write GCM plugin for compatibility with the OpenSSL 1.1 API changes. Since our other platforms still depend on the older API, I've made sure to maintain backwards compatibility. Please let me know if there is a better approach we would like to take with this compatibility issue and I would be glad to follow up on this. 