### PR TITLE
Increase error buffer - libcollectdclient

### DIFF
--- a/src/libcollectdclient/client.c
+++ b/src/libcollectdclient/client.c
@@ -98,7 +98,7 @@
 struct lcc_connection_s
 {
   FILE *fh;
-  char errbuf[1024];
+  char errbuf[2048];
 };
 
 struct lcc_response_s


### PR DESCRIPTION
This contains a cherry picked commit from collectd: collectd/collectd@e170f3559fcda6d37a012aba187a96b1f42e8f9d

While building for Bionic, I was running into the same build failures with gcc 7 mentioned in collectd#2200. My alternative approach was to disable the compiler warnings that are treated as errors. Pulling in this upstream commit should address the root cause instead. 