### PR TITLE
Only build libmongoc if configured to use own bundled version

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -1,14 +1,16 @@
 ACLOCAL_AMFLAGS = -I libltdl/m4
 
-if BUILD_WITH_OWN_LIBMONGOC
-LIBMONGOC_SUBDIR=src/libmongoc
-endif
+SUBDIRS =
 
-SUBDIRS = $(LIBMONGOC_SUBDIR) proto src bindings .
+if BUILD_WITH_OWN_LIBMONGOC
+SUBDIRS += src/libmongoc
+endif
 
 if BUILD_INCLUDED_LTDL
 SUBDIRS += libltdl
 endif
+
+SUBDIRS += proto src bindings .
 
 AM_CPPFLAGS = $(LTDLINCL)
 

--- a/Makefile.am
+++ b/Makefile.am
@@ -11,6 +11,7 @@ SUBDIRS += libltdl
 endif
 
 SUBDIRS += proto src bindings .
+DIST_SUBDIRS = $(SUBDIRS)
 
 AM_CPPFLAGS = $(LTDLINCL)
 

--- a/Makefile.am
+++ b/Makefile.am
@@ -1,12 +1,14 @@
 ACLOCAL_AMFLAGS = -I libltdl/m4
 
-SUBDIRS = src/libmongoc
+if BUILD_WITH_OWN_LIBMONGOC
+LIBMONGOC_SUBDIR=src/libmongoc
+endif
+
+SUBDIRS = $(LIBMONGOC_SUBDIR) proto src bindings .
 
 if BUILD_INCLUDED_LTDL
 SUBDIRS += libltdl
 endif
-
-SUBDIRS += proto src bindings .
 
 AM_CPPFLAGS = $(LTDLINCL)
 

--- a/configure.ac
+++ b/configure.ac
@@ -3058,7 +3058,7 @@ AC_ARG_WITH(libmongoc, [AS_HELP_STRING([--with-libmongoc@<:@=PREFIX@:>@], [Path 
 	     with_libmongoc="yes"
 	     with_own_libmongoc="yes"
 	     AC_DEFINE(OWN_LIBMONGOC, 1, [Define to 1 if we use the shipped mongoc lib.])
-             AC_CONFIG_SUBDIRS([src/libmongoc])
+	     AC_CONFIG_SUBDIRS([src/libmongoc])
 	 else
 	     LIBMONGOC_CPPFLAGS="$LIBMONGOC_CPPFLAGS -I$withval/include"
 	     LIBMONGOC_LDFLAGS="$LIBMONGOC_LDFLAGS -L$withval/lib"

--- a/configure.ac
+++ b/configure.ac
@@ -4,7 +4,10 @@ AC_INIT([collectd],[m4_esyscmd(./version-gen.sh)])
 AC_CONFIG_SRCDIR(src/target_set.c)
 AC_CONFIG_HEADERS(src/config.h)
 AC_CONFIG_AUX_DIR([libltdl/config])
-AC_CONFIG_SUBDIRS([src/libmongoc])
+if test "x$with_libmongoc" = "xown"
+then
+	AC_CONFIG_SUBDIRS([src/libmongoc])
+fi
 
 dnl older automake's default of ARFLAGS=cru is noisy on newer binutils;
 dnl we don't really need the 'u' even in older toolchains.  Then there is

--- a/configure.ac
+++ b/configure.ac
@@ -4,10 +4,6 @@ AC_INIT([collectd],[m4_esyscmd(./version-gen.sh)])
 AC_CONFIG_SRCDIR(src/target_set.c)
 AC_CONFIG_HEADERS(src/config.h)
 AC_CONFIG_AUX_DIR([libltdl/config])
-if test "x$with_libmongoc" = "xown"
-then
-	AC_CONFIG_SUBDIRS([src/libmongoc])
-fi
 
 dnl older automake's default of ARFLAGS=cru is noisy on newer binutils;
 dnl we don't really need the 'u' even in older toolchains.  Then there is
@@ -3062,6 +3058,7 @@ AC_ARG_WITH(libmongoc, [AS_HELP_STRING([--with-libmongoc@<:@=PREFIX@:>@], [Path 
 	     with_libmongoc="yes"
 	     with_own_libmongoc="yes"
 	     AC_DEFINE(OWN_LIBMONGOC, 1, [Define to 1 if we use the shipped mongoc lib.])
+             AC_CONFIG_SUBDIRS([src/libmongoc])
 	 else
 	     LIBMONGOC_CPPFLAGS="$LIBMONGOC_CPPFLAGS -I$withval/include"
 	     LIBMONGOC_LDFLAGS="$LIBMONGOC_LDFLAGS -L$withval/lib"


### PR DESCRIPTION
While building for Ubuntu 18.04, I ran into issues with the bundled version of libmongoc and changes to the openssl API in version 1.1. This PR allows us to temporarily disable libmongoc for Bionic builds, but continue using it for other platforms. 

There is a complementary agents-packaging PR (Stackdriver/agent-packaging#37) which conditionally disables the mongodb plugin when building on Bionic. 

**Note**: the build script will need to be run so `autoconf` and `automake` regenerate the `configure` script and `Makefile`. I have a few open branches for required Bionic build changes and at least one of them also requires running the build script. To avoid merge conflicts, I left this commit out of this PR until everything is merged into the "gabeperez-bionic-build-changes" feature branch. My idea was to run the build script once everything is merged into that branch. Please let me know if you would prefer I include this commit instead.