### PR TITLE
Travis build - distcheck missing man pages target, missing header in dist tarball, and clang errors

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -630,7 +630,7 @@ endif
 
 if BUILD_PLUGIN_MATCH_THROTTLE_METADATA_KEYS
 pkglib_LTLIBRARIES += match_throttle_metadata_keys.la
-match_throttle_metadata_keys_la_SOURCES = match_throttle_metadata_keys.c
+match_throttle_metadata_keys_la_SOURCES = match_throttle_metadata_keys.c stackdriver-agent-keys.h
 match_throttle_metadata_keys_la_LDFLAGS = $(PLUGIN_LDFLAGS)
 endif
 

--- a/src/daemon/plugin.c
+++ b/src/daemon/plugin.c
@@ -694,8 +694,6 @@ static void stop_read_threads (void)
 	pthread_cond_broadcast (&read_cond);
 	pthread_mutex_unlock (&read_lock);
 
-	double sleep_duration = 0.25;
-	sleep(sleep_duration);
 	for (int i = 0; i < read_threads_num; i++)
 	{
 		read_threads[i] = (pthread_t) 0;
@@ -912,8 +910,6 @@ static void stop_write_threads (void) /* {{{ */
 	pthread_cond_broadcast (&write_cond);
 	pthread_mutex_unlock (&write_lock);
 
-	double sleep_duration = 0.25;
-	sleep(sleep_duration);
 	for (i = 0; i < write_threads_num; i++)
 	{
 		write_threads[i] = (pthread_t) 0;

--- a/src/daemon/plugin.c
+++ b/src/daemon/plugin.c
@@ -694,7 +694,8 @@ static void stop_read_threads (void)
 	pthread_cond_broadcast (&read_cond);
 	pthread_mutex_unlock (&read_lock);
 
-	sleep(0.25);
+	double sleep_duration = 0.25;
+	sleep(sleep_duration);
 	for (int i = 0; i < read_threads_num; i++)
 	{
 		read_threads[i] = (pthread_t) 0;
@@ -911,7 +912,8 @@ static void stop_write_threads (void) /* {{{ */
 	pthread_cond_broadcast (&write_cond);
 	pthread_mutex_unlock (&write_lock);
 
-	sleep(0.25);
+	double sleep_duration = 0.25;
+	sleep(sleep_duration);
 	for (i = 0; i < write_threads_num; i++)
 	{
 		write_threads[i] = (pthread_t) 0;

--- a/src/libmongoc/Makefile.am
+++ b/src/libmongoc/Makefile.am
@@ -14,7 +14,7 @@ endif
 
 AM_CTAGSFLAGS = --fields=+l --languages=c
 
-include doc/Makefile.am
+# include doc/Makefile.am
 # if ENABLE_MAN_PAGES
 # include doc/man/Makefile.am
 # endif

--- a/src/write_gcm.c
+++ b/src/write_gcm.c
@@ -2799,7 +2799,7 @@ typedef struct {
 // exhausted. Upon success, the json argument is set to a json string (memory
 // owned by caller), and 0 is returned.
 static int wg_json_CreateCollectdTimeseriesRequest(_Bool pretty,
-    const const monitored_resource_t *monitored_resource,
+    const monitored_resource_t *monitored_resource,
     const wg_payload_t *head, const wg_payload_t **new_head,
     char **json);
 


### PR DESCRIPTION
I ran into Travis build issues with my pull requests for building on Ubuntu 18.04 (#131, #132, #133, #134). After reproducing the issue on a local Travis testing environment, I noticed the issue also happened on the default branch stackdriver-agent-5.5.2. 

I didn't catch these issues earlier since Travis runs extra steps with distcheck:
1. Libmongoc: dist-hook had a missing target "man" used to include man pages. We already have commented out the inclusion of man pages (f0ffe3b22b5647aa0ceb6f8ffd58782644fc05eb) so I also commented out the included docs Makefile to fix this. 
2. The stackdriver-agent-keys header file was missing from the distribution tarball build during distcheck. I updated the Makefile to include this. 
3. There were also a few warnings/errors that only came up with clang that I needed to address in order for the build to work as well. There was an implicit conversion error (from double to int) in the collectd daemon/plugin.c file and a duplicate const declaration error in write_gcm. 

Please let me know if there is a different branch I should merge these changes into. I can merge them into my bionic build feature branch (gabeperez-bionic-build-changes) instead if that's preferred. 