### PR TITLE
Removed references to `ping` plugin

### DIFF
--- a/src/collectd.conf.pod
+++ b/src/collectd.conf.pod
@@ -20,12 +20,6 @@ collectd.conf - Configuration for the system statistics collection daemon B<coll
     ValuesPercentage true
   </Plugin>
 
-  LoadPlugin ping
-  <Plugin ping>
-    Host "example.org"
-    Host "provider.net"
-  </Plugin>
-
 =head1 DESCRIPTION
 
 This config file controls how the system statistics collection daemon
@@ -5324,73 +5318,6 @@ C<$_SERVER["SCRIPT_NAME"]> variable when within PHP. If not configured, all
 script names will be accepted.
 
 =back
-
-=back
-
-=head2 Plugin C<ping>
-
-The I<Ping> plugin starts a new thread which sends ICMP "ping" packets to the
-configured hosts periodically and measures the network latency. Whenever the
-C<read> function of the plugin is called, it submits the average latency, the
-standard deviation and the drop rate for each host.
-
-Available configuration options:
-
-=over 4
-
-=item B<Host> I<IP-address>
-
-Host to ping periodically. This option may be repeated several times to ping
-multiple hosts.
-
-=item B<Interval> I<Seconds>
-
-Sets the interval in which to send ICMP echo packets to the configured hosts.
-This is B<not> the interval in which statistics are queries from the plugin but
-the interval in which the hosts are "pinged". Therefore, the setting here
-should be smaller than or equal to the global B<Interval> setting. Fractional
-times, such as "1.24" are allowed.
-
-Default: B<1.0>
-
-=item B<Timeout> I<Seconds>
-
-Time to wait for a response from the host to which an ICMP packet had been
-sent. If a reply was not received after I<Seconds> seconds, the host is assumed
-to be down or the packet to be dropped. This setting must be smaller than the
-B<Interval> setting above for the plugin to work correctly. Fractional
-arguments are accepted.
-
-Default: B<0.9>
-
-=item B<TTL> I<0-255>
-
-Sets the Time-To-Live of generated ICMP packets.
-
-=item B<Size> I<size>
-
-Sets the size of the data payload in ICMP packet to specified I<size> (it
-will be filled with regular ASCII pattern). If not set, default 56 byte
-long string is used so that the packet size of an ICMPv4 packet is exactly
-64 bytes, similar to the behaviour of normal ping(1) command.
-
-=item B<SourceAddress> I<host>
-
-Sets the source address to use. I<host> may either be a numerical network
-address or a network hostname.
-
-=item B<Device> I<name>
-
-Sets the outgoing network device to be used. I<name> has to specify an
-interface name (e.E<nbsp>g. C<eth0>). This might not be supported by all
-operating systems.
-
-=item B<MaxMissed> I<Packets>
-
-Trigger a DNS resolve after the host has not replied to I<Packets> packets. This
-enables the use of dynamic DNS services (like dyndns.org) with the ping plugin.
-
-Default: B<-1> (disabled)
 
 =back
 


### PR DESCRIPTION
We don't bundle it in the Stackdriver agent.