### PR TITLE
Remove unreachable else clause.

### DIFF
--- a/src/aggregation.c
+++ b/src/aggregation.c
@@ -202,13 +202,9 @@ static int agg_instance_create_name(agg_instance_t *inst, /* {{{ */
     else if (strcmp("", tmp_plugin) != 0)
       snprintf(inst->ident.plugin_instance, sizeof(inst->ident.plugin_instance),
                "%s-%s", tmp_plugin, AGG_FUNC_PLACEHOLDER);
-    else if (strcmp("", tmp_plugin_instance) != 0)
-      snprintf(inst->ident.plugin_instance, sizeof(inst->ident.plugin_instance),
-               "%s-%s", tmp_plugin_instance, AGG_FUNC_PLACEHOLDER);
     else
       snprintf(inst->ident.plugin_instance, sizeof(inst->ident.plugin_instance),
-               "%s-%s-%s", tmp_plugin, tmp_plugin_instance,
-               AGG_FUNC_PLACEHOLDER);
+               "%s-%s", tmp_plugin_instance, AGG_FUNC_PLACEHOLDER);
   }
 
   /* Type */


### PR DESCRIPTION
One side effect of this change is to avoid errors like:

```
src/aggregation.c: In function 'agg_instance_create_name':
src/aggregation.c:210:20: error: '%s' directive output may be truncated writing up to 112 bytes into a region of size between 15 and 127 [-Werror=format-truncation=]
                "%s-%s-%s", tmp_plugin, tmp_plugin_instance,
                    ^~                  ~~~~~~~~~~~~~~~~~~~
src/aggregation.c:209:7: note: 'snprintf' output between 17 and 241 bytes into a destination of size 128
       snprintf(inst->ident.plugin_instance, sizeof(inst->ident.plugin_instance),
       ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
                "%s-%s-%s", tmp_plugin, tmp_plugin_instance,
                ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
                AGG_FUNC_PLACEHOLDER);
                ~~~~~~~~~~~~~~~~~~~~~
cc1: all warnings being treated as errors
make[3]: *** [Makefile:6209: src/aggregation.lo] Error 1
```