### PR TITLE
Fixed camel case in JSON replies from API server.

### DIFF
--- a/src/collectd_time_series_response_test.json
+++ b/src/collectd_time_series_response_test.json
@@ -1,12 +1,12 @@
 {
-   "payload_errors" : [
+   "payloadErrors" : [
       {
          "error" : {
             "message" : "Retry in 300 milliseconds.",
             "status" : "RESOURCE_EXHAUSTED",
             "code" : 429
          },
-         "value_errors" : [
+         "valueErrors" : [
             {
                "index" : 0
             }
@@ -15,7 +15,7 @@
       },
       {
          "index" : 1,
-         "value_errors" : [
+         "valueErrors" : [
             {
                "error" : {
                   "status" : "RESOURCE_EXHAUSTED",
@@ -38,7 +38,7 @@
    "summary" : {
       "errors" : [
          {
-            "point_count" : 2,
+            "pointCount" : 2,
             "status" : {
                "message" : "Retry in 500 milliseconds.",
                "status" : "RESOURCE_EXHAUSTED",
@@ -50,10 +50,10 @@
                "status" : "NOT_FOUND",
                "code" : 404
             },
-            "point_count" : 1
+            "pointCount" : 1
          }
       ],
-      "total_point_count" : 4,
-      "success_point_count" : 1
+      "totalPointCount" : 4,
+      "successPointCount" : 1
    }
 }

--- a/src/time_series_summary_test.json
+++ b/src/time_series_summary_test.json
@@ -5,8 +5,8 @@
       "details" : [
          {
             "@type" : "type.googleapis.com/google.monitoring.v3.CreateTimeSeriesSummary",
-            "success_point_count" : 1,
-            "total_point_count" : 4,
+            "successPointCount" : 1,
+            "totalPointCount" : 4,
             "errors" : [
                {
                   "status" : {
@@ -14,19 +14,19 @@
                      "message" : "Retry in 500 milliseconds.",
                      "status" : "RESOURCE_EXHAUSTED"
                   },
-                  "point_count" : 2
+                  "pointCount" : 2
                },
                {
                   "status" : {
                      "code" : 404,
                      "status" : "NOT_FOUND"
                   },
-                  "point_count" : 1
+                  "pointCount" : 1
                }
             ]
          },
          {
-            "time_series" : {},
+            "timeSeries" : {},
             "@type" : "type.googleapis.com/google.monitoring.v3.CreateTimeSeriesError",
             "status" : {
                "code" : 429,

--- a/src/utils_stackdriver_json.c
+++ b/src/utils_stackdriver_json.c
@@ -171,11 +171,11 @@ static int summary_parse_map_key(void *c, const unsigned char *key,
   }
   // We are inside a summary object. This implementation assumes that the field
   // names used within the message are unique.
-  if (strncmp((const char *)key, "total_point_count", length) == 0) {
+  if (strncmp((const char *)key, "totalPointCount", length) == 0) {
     ctx->state.current_field = FIELD_TOTAL_POINT_COUNT;
-  } else if (strncmp((const char *)key, "success_point_count", length) == 0) {
+  } else if (strncmp((const char *)key, "successPointCount", length) == 0) {
     ctx->state.current_field = FIELD_SUCCESS_POINT_COUNT;
-  } else if (strncmp((const char *)key, "point_count", length) == 0) {
+  } else if (strncmp((const char *)key, "pointCount", length) == 0) {
     // Not a typo. The field name doesn't contain "error".
     ctx->state.current_field = FIELD_ERROR_POINT_COUNT;
   } else if (strncmp((const char *)key, "code", length) == 0) {
@@ -204,17 +204,17 @@ static int summary_parse_integer(void *c, wg_yajl_integer_t val) {
   DEBUG("integer: %lld", val);
   if (ctx->state.current_field == FIELD_TOTAL_POINT_COUNT) {
     if (ctx->response->total_point_count > 0) {
-      DEBUG("total_point_count was already set. Bug?");
+      DEBUG("totalPointCount was already set. Bug?");
     }
     ctx->response->total_point_count += val;
   } else if (ctx->state.current_field == FIELD_SUCCESS_POINT_COUNT) {
     if (ctx->response->success_point_count > 0) {
-      DEBUG("success_point_count was already set. Bug?");
+      DEBUG("successPointCount was already set. Bug?");
     }
     ctx->response->success_point_count += val;
   } else if (ctx->state.current_field == FIELD_ERROR_POINT_COUNT) {
     if (ctx->state.temp_error.point_count > 0) {
-      DEBUG("error point_count was already set. Bug?");
+      DEBUG("error pointCount was already set. Bug?");
     }
     ctx->state.temp_error.point_count += val;
   } else if (ctx->state.current_field == FIELD_CODE) {


### PR DESCRIPTION
I was now able to obtain an actual response from the server, and noticed that the keys are 'fooBar' instead of 'foo_bar'.