### PR TITLE
Dropped `name` field from API requests

### DIFF
--- a/src/write_gcm.c
+++ b/src/write_gcm.c
@@ -2893,7 +2893,7 @@ static int wg_json_CreateCollectdTimeseriesRequest(
     const wg_payload_t *head, const wg_payload_t **new_head, char **json)
 {
   char name[256];
-  int result = snprintf(name, sizeof(name), "project/%s",
+  int result = snprintf(name, sizeof(name), "projects/%s",
       monitored_resource->project_id);
   if (result < 0 || result >= sizeof(name)) {
     ERROR("write_gcm: project_id %s doesn't fit in buffer.",
@@ -3163,7 +3163,7 @@ static int wg_json_CreateTimeSeriesRequest(
     const wg_payload_t *head, const wg_payload_t **new_head, char **json)
 {
   char name[256];
-  int result = snprintf(name, sizeof(name), "project/%s",
+  int result = snprintf(name, sizeof(name), "projects/%s",
       monitored_resource->project_id);
   if (result < 0 || result >= sizeof(name)) {
     ERROR("write_gcm: project_id %s doesn't fit in buffer.",

--- a/src/write_gcm.c
+++ b/src/write_gcm.c
@@ -2892,15 +2892,6 @@ static int wg_json_CreateCollectdTimeseriesRequest(
     _Bool pretty, const monitored_resource_t *monitored_resource,
     const wg_payload_t *head, const wg_payload_t **new_head, char **json)
 {
-  char name[256];
-  int result = snprintf(name, sizeof(name), "projects/%s",
-      monitored_resource->project_id);
-  if (result < 0 || result >= sizeof(name)) {
-    ERROR("write_gcm: project_id %s doesn't fit in buffer.",
-        monitored_resource->project_id);
-    return -ENOMEM;
-  }
-
   json_ctx_t *jc = wg_json_ctx_create(pretty);
   if (jc == NULL) {
     ERROR("write_gcm: wg_json_ctx_create failed");
@@ -2908,9 +2899,6 @@ static int wg_json_CreateCollectdTimeseriesRequest(
   }
 
   wg_json_map_open(jc);
-  wg_json_string(jc, "name");
-  wg_json_string(jc, name);
-
   wg_json_string(jc, "resource");
   wg_json_MonitoredResource(jc, monitored_resource);
 
@@ -3162,15 +3150,6 @@ static int wg_json_CreateTimeSeriesRequest(
     _Bool pretty, const monitored_resource_t *monitored_resource,
     const wg_payload_t *head, const wg_payload_t **new_head, char **json)
 {
-  char name[256];
-  int result = snprintf(name, sizeof(name), "projects/%s",
-      monitored_resource->project_id);
-  if (result < 0 || result >= sizeof(name)) {
-    ERROR("write_gcm: project_id %s doesn't fit in buffer.",
-          monitored_resource->project_id);
-    return -ENOMEM;
-  }
-
   json_ctx_t *jc = wg_json_ctx_create(pretty);
   if (jc == NULL) {
     ERROR("write_gcm: wg_json_ctx_create failed");


### PR DESCRIPTION
The prefix can only be one of "projects/", "folders/", "organizations/", but currently, probably due to a typo, it's "project/".