### PR TITLE
Restrict <sys/sysctl.h> to BSD variants, to remove deprecation warnings.

### DIFF
--- a/src/contextswitch.c
+++ b/src/contextswitch.c
@@ -26,11 +26,8 @@
 #include "common.h"
 #include "plugin.h"
 
-#ifdef HAVE_SYS_SYSCTL_H
+#if defined(HAVE_SYSCTLBYNAME) && defined(HAVE_SYS_SYSCTL_H)
 #include <sys/sysctl.h>
-#endif
-
-#if HAVE_SYSCTLBYNAME
 /* no global variables */
 /* #endif HAVE_SYSCTLBYNAME */
 

--- a/src/cpu.c
+++ b/src/cpu.c
@@ -58,15 +58,14 @@
 #include <sys/sysinfo.h>
 #endif /* HAVE_LIBKSTAT */
 
-#if (defined(HAVE_SYSCTL) && HAVE_SYSCTL) ||                                   \
-    (defined(HAVE_SYSCTLBYNAME) && HAVE_SYSCTLBYNAME)
-#ifdef HAVE_SYS_SYSCTL_H
+#if (defined(HAVE_SYSCTL) && defined(HAVE_SYSCTLBYNAME)) || defined(__OpenBSD__)
+/* Implies BSD variant */
 #include <sys/sysctl.h>
 #endif
 
 #ifdef HAVE_SYS_DKSTAT_H
+/* Implies BSD variant */
 #include <sys/dkstat.h>
-#endif
 
 #if !defined(CP_USER) || !defined(CP_NICE) || !defined(CP_SYS) ||              \
     !defined(CP_INTR) || !defined(CP_IDLE) || !defined(CPUSTATES)
@@ -77,18 +76,16 @@
 #define CP_IDLE 4
 #define CPUSTATES 5
 #endif
-#endif /* HAVE_SYSCTL || HAVE_SYSCTLBYNAME */
+#endif /* HAVE_SYS_DKSTAT_H */
 
-#if HAVE_SYSCTL
+#define CAN_USE_SYSCTL 0
+#if (defined(HAVE_SYSCTL) && defined(HAVE_SYSCTLBYNAME)) || defined(__OpenBSD__)
+/* Implies BSD variant */
 #if defined(CTL_HW) && defined(HW_NCPU) && defined(CTL_KERN) &&                \
     defined(KERN_CPTIME) && defined(CPUSTATES)
 #define CAN_USE_SYSCTL 1
-#else
-#define CAN_USE_SYSCTL 0
 #endif
-#else
-#define CAN_USE_SYSCTL 0
-#endif
+#endif /* HAVE_SYSCTL_H && HAVE_SYSCTLBYNAME || __OpenBSD__ */
 
 #define COLLECTD_CPU_STATE_USER 0
 #define COLLECTD_CPU_STATE_SYSTEM 1
@@ -146,10 +143,12 @@ static int numcpu;
 /* #endif HAVE_LIBKSTAT */
 
 #elif CAN_USE_SYSCTL
+/* Only possible for (Open) BSD variant */
 static int numcpu;
 /* #endif CAN_USE_SYSCTL */
 
 #elif defined(HAVE_SYSCTLBYNAME)
+/* Implies BSD variant */
 static int numcpu;
 #ifdef HAVE_SYSCTL_KERN_CP_TIMES
 static int maxcpu;
@@ -270,6 +269,7 @@ static int init(void) {
 /* #endif HAVE_LIBKSTAT */
 
 #elif CAN_USE_SYSCTL
+  /* Only on (Open) BSD variant */
   size_t numcpu_size;
   int mib[2] = {CTL_HW, HW_NCPU};
   int status;
@@ -286,6 +286,7 @@ static int init(void) {
 /* #endif CAN_USE_SYSCTL */
 
 #elif defined(HAVE_SYSCTLBYNAME)
+  /* Only on BSD variant */
   size_t numcpu_size;
 
   numcpu_size = sizeof(numcpu);
@@ -741,6 +742,7 @@ static int cpu_read(void) {
 /* }}} #endif defined(HAVE_LIBKSTAT) */
 
 #elif CAN_USE_SYSCTL /* {{{ */
+  /* Only on (Open) BSD variant */
   uint64_t cpuinfo[numcpu][CPUSTATES];
   size_t cpuinfo_size;
   int status;
@@ -803,6 +805,7 @@ static int cpu_read(void) {
 
 #elif defined(HAVE_SYSCTLBYNAME) && defined(HAVE_SYSCTL_KERN_CP_TIMES) /* {{{  \
                                                                           */
+  /* Only on BSD variant */
   long cpuinfo[maxcpu][CPUSTATES];
   size_t cpuinfo_size;
 
@@ -827,6 +830,7 @@ static int cpu_read(void) {
 /* }}} #endif HAVE_SYSCTL_KERN_CP_TIMES */
 
 #elif defined(HAVE_SYSCTLBYNAME) /* {{{ */
+  /* Only on BSD variant */
   long cpuinfo[CPUSTATES];
   size_t cpuinfo_size;
 

--- a/src/memory.c
+++ b/src/memory.c
@@ -28,7 +28,9 @@
 #include "common.h"
 #include "plugin.h"
 
-#ifdef HAVE_SYS_SYSCTL_H
+#if (defined(HAVE_SYS_SYSCTL_H) && defined(HAVE_SYSCTLBYNAME)) ||              \
+    defined(__OpenBSD__)
+/* Implies BSD variant */
 #include <sys/sysctl.h>
 #endif
 #ifdef HAVE_SYS_VMMETER_H
@@ -80,9 +82,10 @@ static kstat_t *ksp;
 static kstat_t *ksz;
 /* #endif HAVE_LIBKSTAT */
 
-#elif HAVE_SYSCTL
+#elif HAVE_SYSCTL && __OpenBSD__
+/* OpenBSD variant does not have sysctlbyname */
 static int pagesize;
-/* #endif HAVE_SYSCTL */
+/* #endif HAVE_SYSCTL && __OpenBSD__ */
 
 #elif HAVE_LIBSTATGRAB
 /* no global variables */
@@ -142,13 +145,14 @@ static int memory_init(void) {
 
 /* #endif HAVE_LIBKSTAT */
 
-#elif HAVE_SYSCTL
+#elif HAVE_SYSCTL && __OpenBSD__
+  /* OpenBSD variant does not have sysctlbyname */
   pagesize = getpagesize();
   if (pagesize <= 0) {
     ERROR("memory plugin: Invalid pagesize: %i", pagesize);
     return -1;
   }
-/* #endif HAVE_SYSCTL */
+/* #endif HAVE_SYSCTL && __OpenBSD__ */
 
 #elif HAVE_LIBSTATGRAB
 /* no init stuff */
@@ -391,7 +395,8 @@ static int memory_read_internal(value_list_t *vl) {
                 (gauge_t)arcsize, "unusable", (gauge_t)mem_unus);
 /* #endif HAVE_LIBKSTAT */
 
-#elif HAVE_SYSCTL
+#elif HAVE_SYSCTL && __OpenBSD__
+  /* OpenBSD variant does not have HAVE_SYSCTLBYNAME */
   int mib[] = {CTL_VM, VM_METER};
   struct vmtotal vmtotal = {0};
   gauge_t mem_active;
@@ -415,7 +420,7 @@ static int memory_read_internal(value_list_t *vl) {
 
   MEMORY_SUBMIT("active", mem_active, "inactive", mem_inactive, "free",
                 mem_free);
-/* #endif HAVE_SYSCTL */
+/* #endif HAVE_SYSCTL && __OpenBSD__ */
 
 #elif HAVE_LIBSTATGRAB
   sg_mem_stats *ios;

--- a/src/swap.c
+++ b/src/swap.c
@@ -49,7 +49,9 @@
 #if HAVE_SYS_PARAM_H
 #include <sys/param.h>
 #endif
-#if HAVE_SYS_SYSCTL_H
+#if (defined(HAVE_SYS_SYSCTL_H) && defined(HAVE_SYSCTLBYNAME)) ||              \
+    defined(__OpenBSD__)
+/* Implies BSD variant */
 #include <sys/sysctl.h>
 #endif
 #if HAVE_SYS_DKSTAT_H

--- a/src/uuid.c
+++ b/src/uuid.c
@@ -29,7 +29,9 @@
 #include "common.h"
 #include "plugin.h"
 
-#if HAVE_SYS_SYSCTL_H
+#if defined(HAVE_SYS_SYSCTL_H) && defined(HAVE_SYSCTLBYNAME) ||                \
+    defined(__OpenBSD__)
+/* Implies BSD variant */
 #include <sys/sysctl.h>
 #endif
 


### PR DESCRIPTION
Deprecation warnings started with [glibc release 2.30](https://lwn.net/Articles/795164/). See collectd discussion: https://github.com/collectd/collectd/issues/3338. Collectd is built with -Werror, so the deprecated header warning killed the build. 

This PR is a combination of:
- https://github.com/collectd/collectd/pull/3342
- https://github.com/collectd/collectd/pull/3298

Only tested on Ubuntu 19.10 by building and running the monitoring agent.