### PR TITLE
Adjust the format specifier based on the typedef for wg_yajl_integer_t.

### DIFF
--- a/src/utils_stackdriver_json.c
+++ b/src/utils_stackdriver_json.c
@@ -37,9 +37,11 @@
 
 #if HAVE_YAJL_V2
 typedef long long wg_yajl_integer_t;
+#define PRIyi "%lld"
 typedef size_t wg_yajl_size_t;
 #else
 typedef long wg_yajl_integer_t;
+#define PRIyi "%ld"
 typedef unsigned int wg_yajl_size_t;
 #endif
 
@@ -193,7 +195,7 @@ static int summary_parse_string(void *c, const unsigned char *val,
 static int summary_parse_integer(void *c, wg_yajl_integer_t val) {
   parse_summary_t *ctx = (parse_summary_t *)c;
   log_context(ctx);
-  DEBUG("integer: %lld", val);
+  DEBUG("integer: " PRIyi, val);
   if (ctx->state.current_field == FIELD_TOTAL_POINT_COUNT) {
     if (ctx->response->total_point_count > 0) {
       DEBUG("totalPointCount was already set. Bug?");


### PR DESCRIPTION
Should fix the following build error on platforms with libyajl1:
```
src/utils_stackdriver_json.c: In function 'summary_parse_integer':
src/utils_stackdriver_json.c:196:3: error: format '%lld' expects argument of type 'long long int', but argument 3 has type 'wg_yajl_integer_t' [-Werror=format=]
   DEBUG("integer: %lld", val);
   ^
```