### PR TITLE
Fix builds with versions of automake prior to 1.13.

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -48,7 +48,7 @@ fi
 set -x
 
 autoheader \
-&& aclocal \
 && $libtoolize --copy --force \
+&& aclocal -Im4 \
 && automake --add-missing --copy \
 && autoconf


### PR DESCRIPTION
This fixes the following build error on older platforms:
```
./configure: line 37411: syntax error near unexpected token `$am__api_version,lt,1.12,'
./configure: line 37411: `AX_COMPARE_VERSION($am__api_version,lt,1.12,'
```
A bit of context for the change: older versions of `automake` did not automatically parse the `AC_CONFIG_MACRO_DIR` directive, so we have to explicitly tell `aclocal` to find extra macros there. Also, running `libtoolize` before `aclocal` ensures that the libtool macros have been copied into `m4` for `aclocal` to find (otherwise it would sporadically use the libtool macros that came with whatever version of `automake` was installed, rather than those supplied by libtool itself).