### PR TITLE
Fixing issue created by new mingw compiler.

### DIFF
--- a/src/libcollectdclient/network_parse.c
+++ b/src/libcollectdclient/network_parse.c
@@ -535,7 +535,7 @@ static int network_parse(void *data, size_t data_size, lcc_security_level_t sl,
 
     if ((sz < 5) || (((size_t)sz - 4) > b->len)) {
       DEBUG("lcc_network_parse(): invalid 'sz' field: sz = %" PRIu16
-            ", b->len = %" PRIsz "\n",
+            ", b->len = %" PRIu64 "\n",
             sz, b->len);
       return EINVAL;
     }


### PR DESCRIPTION
Fixes:
src/libcollectdclient/network_parse.c: In function 'network_parse':

src/libcollectdclient/network_parse.c:537:13: error: format '%u' expects argument of type 'unsigned int', but argument 3 has type 'size_t' {aka 'long long unsigned int'} [-Werror=format=]

  537 |       DEBUG("lcc_network_parse(): invalid 'sz' field: sz = %" PRIu16

      |             ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

  538 |             ", b->len = %" PRIsz "\n",

  539 |             sz, b->len);

      |                 ~~~~~~

      |                  |

      |                  size_t {aka long long unsigned int}

src/libcollectdclient/network_parse.c:72:27: note: in definition of macro 'DEBUG'

   72 | #define DEBUG(...) printf(__VA_ARGS__)

      |                           ^~~~~~~~~~~

In file included from src/libcollectdclient/network_parse.c:34:

./src/daemon/globals.h:35:17: note: format string is defined here

   35 | #define PRIsz "Iu"

cc1: all warnings being treated as errors

make[1]: *** [Makefile:6545: src/libcollectdclient/libcollectdclient_la-network_parse.lo] Error 1

make[1]: Leaving directory '/tmpfs/src/collectd_src'

make: *** [Makefile:4578: all] Error 2