### PR TITLE
configure: check for the newer SSL init symbol

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@ on: [push, pull_request]
 name: Test
 jobs:
   test:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     env:
       CC: gcc
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@ on: [push, pull_request]
 name: Test
 jobs:
   test:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-18.04
     env:
       CC: gcc
     steps:

--- a/configure.ac
+++ b/configure.ac
@@ -5171,9 +5171,9 @@ if test "x$with_libssl" = "xyes"; then
   CPPFLAGS="$CPPFLAGS $with_libssl_cppflags"
   LDFLAGS="$LDFLAGS $with_libssl_ldflags"
 
-  AC_CHECK_LIB([ssl], [SSL_library_init],
+  AC_CHECK_LIB([ssl], [OPENSSL_init_ssl],
     [with_libssl="yes"],
-    [with_libssl="no (Symbol 'SSL_library_init' not found)"]
+    [with_libssl="no (Symbol 'OPENSSL_init_ssl' not found)"]
   )
 
   CPPFLAGS="$SAVE_CPPFLAGS"


### PR DESCRIPTION
SSL_library_init was deprecated in OpenSSL 1.0. We now need to check for OPENSSL_init_ssl to properly declare our dependency on libssl.

[b/350819869](http://b/350819869)